### PR TITLE
Unify tasks, notes, and events into a single items model

### DIFF
--- a/.github/PLAN.md
+++ b/.github/PLAN.md
@@ -4,27 +4,36 @@
 
 ## Key Decisions
 
-| Decision        | Choice                                                     | Rationale                                                                                                 |
-| --------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Backend         | TanStack Start server functions + Drizzle ORM + PostgreSQL | No separate API framework — server functions already exist, just swap data layer                          |
-| ORM             | Drizzle                                                    | Lightweight, type-safe, SQL-like syntax                                                                   |
-| Database        | PostgreSQL (via docker-compose)                            | Relational, full-text search built-in, dev container provides it                                          |
-| AI Provider     | Provider-agnostic abstraction                              | Start with xAI/Grok, design to swap to OpenAI/Ollama/Anthropic. Uses `openai` SDK with custom base URL    |
-| AI Notes        | Metadata table + PostgreSQL full-text search               | AI generates title (if none given) + keywords on save. `tsvector`/`tsquery` for search, no embeddings yet |
-| Auth            | Deferred (Phase 8)                                         | userId column baked in from day one, hardcode '1' for now                                                 |
-| Tags            | Flat tag system                                            | Tags are the sole organizational mechanism — flexible, orthogonal, many-to-many                           |
-| Notes Format    | Tiptap rich text editor, stored as markdown                | Tiptap for editing, markdown for portable storage and full-text indexing                                  |
-| Deployment      | Local only for now                                         | Docker Compose with PostgreSQL, simple local setup                                                        |
-| Codebase        | Evolve existing — don't start fresh                        | Reuse TanStack Start, React Query, dnd-kit, Tailwind foundations                                          |
-| Testing         | Vitest (unit/integration) + Playwright (E2E)               | Vitest already set up; Playwright pairs well with Vite stack, cross-browser, great TypeScript support     |
-| Dev Environment | Dev container (Docker)                                     | Reproducible setup, Playwright browsers pre-installed, Codespaces-ready                                   |
+| Decision        | Choice                                                     | Rationale                                                                                                                                                                                                            |
+| --------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend         | TanStack Start server functions + Drizzle ORM + PostgreSQL | No separate API framework — server functions already exist, just swap data layer                                                                                                                                     |
+| ORM             | Drizzle                                                    | Lightweight, type-safe, SQL-like syntax                                                                                                                                                                              |
+| Database        | PostgreSQL (via docker-compose)                            | Relational, full-text search built-in, dev container provides it                                                                                                                                                     |
+| Data Model      | **Unified `items` table** with `type` column               | Tasks, notes, and events are all "titled things with content, a date, and tags". Behavioral differences via `type` column + conditional UI. One tag junction, one metadata table, simpler queries, future types free |
+| Scheduling      | **`schedules` table** attached to any item                 | Reminders/recurrence are orthogonal to item type. A schedule attaches to any item — `cloneOnFire` for task-generating reminders, plain notify for events                                                             |
+| AI Provider     | Provider-agnostic abstraction                              | Start with xAI/Grok, design to swap to OpenAI/Ollama/Anthropic. Uses `openai` SDK with custom base URL                                                                                                               |
+| AI Notes        | Metadata table + PostgreSQL full-text search               | AI generates title (if none given) + keywords on save. `tsvector`/`tsquery` for search, no embeddings yet                                                                                                            |
+| Auth            | Deferred (Phase 10)                                        | userId column baked in from day one, hardcode '1' for now                                                                                                                                                            |
+| Tags            | Flat tag system                                            | Tags are the sole organizational mechanism — flexible, orthogonal, many-to-many                                                                                                                                      |
+| Notes Format    | Tiptap rich text editor, stored as markdown                | Tiptap for editing, markdown for portable storage and full-text indexing                                                                                                                                             |
+| Deployment      | Local only for now                                         | Docker Compose with PostgreSQL, simple local setup                                                                                                                                                                   |
+| Codebase        | Evolve existing — don't start fresh                        | Reuse TanStack Start, React Query, dnd-kit, Tailwind foundations                                                                                                                                                     |
+| Testing         | Vitest (unit/integration) + Playwright (E2E)               | Vitest already set up; Playwright pairs well with Vite stack, cross-browser, great TypeScript support                                                                                                                |
+| Dev Environment | Dev container (Docker)                                     | Reproducible setup, Playwright browsers pre-installed, Codespaces-ready                                                                                                                                              |
 
 ### Simplification Decisions (Post-Phase 5)
 
 - **Priority categories removed** — original plan had configurable priority categories (Business-Critical, Momentum Builders, etc.). Simplified to just tags for organization.
-- **Recurrence removed** — `rrule` engine and `RecurrencePicker` were cut. Tasks use `startDate` only.
+- **Recurrence removed from tasks** — tasks use `startDate` only. Recurrence lives in the `schedules` system (Phase 9) — schedules with `cloneOnFire` create fresh tasks on a schedule.
 - **Lists removed** — `lists` and `listItems` tables were never implemented. Backlog + day view replaces static lists.
 - **`dueDate` → `startDate`** — renamed to better reflect the concept: the day a task appears in your day view.
+
+### Architectural Pivot (Post-Phase 7)
+
+- **Unified `items` table** — tasks, notes, and events (reminders) were originally separate tables (`tasks`, `notes`). In Phase 8 we migrate to a single `items` table with a `type` column (`task` | `note` | `event`). This halves the schema, eliminates duplicate junction tables, and makes tag pages/day views trivial (one query instead of UNION across tables). Separate pages and UI components remain — the unification is at the data layer.
+- **`schedules` replaces `reminders`** — scheduling (reminder times, RRULE recurrence, snooze) is orthogonal to item type. A `schedules` table attaches to any item. Event items + schedule = timed notification. Task items + schedule + `cloneOnFire` = recurring task generation.
+- **One junction table** — `itemTags` replaces `taskTags` + `noteTags`. Same tag pool, single query.
+- **One metadata table** — `itemMetadata` replaces `noteMetadata`. AI-generated keywords/embeddings can apply to any item type.
 
 ---
 
@@ -443,7 +452,373 @@
 
 ---
 
-## Phase 8: Multi-User & Auth (Future)
+## Phase 8: Unified Items Architecture (Migration)
+
+> Migrate from separate `tasks`/`notes` tables to a single `items` table with a `type` column. This unifies the data layer — tasks, notes, and the new event type all become items. All existing pages, routes, and UI components remain separate. Data is migrated without loss.
+
+### Why Now
+
+The app has a small dataset, the schema is young, and we're about to add a third entity type (events/reminders). Adding another set of tables + junction table + server functions would triple the boilerplate. A unified model means:
+
+- **One tag junction** (`itemTags`) instead of three (`taskTags`, `noteTags`, `reminderTags`)
+- **Tag page is one query** — no UNION across three tables
+- **Day view is one query** — filter by date, get tasks + notes + events together
+- **Future types are free** — habits, bookmarks, etc. require zero new tables
+- **Half the server functions** — one CRUD set with type filters
+
+### 8A: New Schema
+
+- [ ] Create `items` table in `src/db/schema.ts`:
+  - `id` (text PK — prefixed: `tsk_`, `nte_`, `evt_` by type)
+  - `type` (text NOT NULL — `task` | `note` | `event`)
+  - `title` (text NOT NULL)
+  - `content` (text, nullable — task notes, note body, event description)
+  - `date` (text, nullable — `startDate` for tasks, display date for notes, event date)
+  - `dateCompleted` (text, nullable — tasks only)
+  - `parentItemId` (text, nullable — self-ref FK for subtasks)
+  - `sortOrder` (text NOT NULL, default `'a0'` — fractional indexing)
+  - `userId` (text NOT NULL)
+  - `dateCreated` (text NOT NULL)
+  - `dateUpdated` (text NOT NULL)
+- [ ] Create `itemTags` junction table:
+  - `itemId` (text FK → items.id CASCADE)
+  - `tagId` (text FK → tags.id CASCADE)
+  - Composite PK (itemId, tagId)
+- [ ] Create `itemMetadata` table (replaces `noteMetadata`):
+  - `itemId` (text PK, FK → items.id CASCADE — one-to-one)
+  - `keywords` (text, nullable — AI-generated)
+  - `embedding` (bytea, nullable — future vector search)
+- [ ] Add relations: `itemsRelations` (self-ref subtasks, many itemTags, one itemMetadata, many schedules), `itemTagsRelations`, `itemMetadataRelations`. Update `tagsRelations` to reference `itemTags`.
+- [ ] Keep `tags` table unchanged — tags are already clean
+
+### 8B: Data Migration
+
+- [ ] Write Drizzle migration that:
+  1. Creates `items`, `itemTags`, `itemMetadata` tables
+  2. Copies `tasks` → `items` with `type = 'task'`:
+     - `id` → `id` (keep existing IDs)
+     - `title` → `title`
+     - `notes` → `content`
+     - `startDate` → `date`
+     - `dateCompleted` → `dateCompleted`
+     - `parentTaskId` → `parentItemId`
+     - `sortOrder` → `sortOrder` (already text)
+     - `dateCreated` → `dateCreated`
+     - Set `dateUpdated` = `dateCreated` (tasks didn't track this)
+  3. Copies `notes` → `items` with `type = 'note'`:
+     - `id` → `id`
+     - `title` → `title` (nullable → use `'Untitled'` fallback)
+     - `content` → `content`
+     - `date` → `date`
+     - `sortOrder` → `sortOrder` (convert integer to text: `CAST(sort_order AS TEXT)`)
+     - `dateCreated` → `dateCreated`, `dateUpdated` → `dateUpdated`
+  4. Copies `taskTags` → `itemTags` (taskId → itemId)
+  5. Copies `noteTags` → `itemTags` (noteId → itemId)
+  6. Copies `noteMetadata` → `itemMetadata` (noteId → itemId)
+  7. Drops old tables: `tasks`, `notes`, `taskTags`, `noteTags`, `noteMetadata`
+- [ ] Create `src/db/migrate-data.ts` — standalone migration script (can be run independently, idempotent)
+- [ ] Test migration locally: `pnpm db:generate && pnpm db:migrate` — verify zero data loss
+- [ ] Update `src/db/seed.ts`:
+  - Seed items of all three types (tasks, notes, events)
+  - Seed itemTags for all types
+  - Seed itemMetadata for notes
+
+### 8C: Update Feature Modules
+
+- [ ] Create `src/features/items/` — shared base layer:
+  - `types.ts` — `Item` base type, `ItemType` enum (`task` | `note` | `event`), `Task`/`Note`/`Event` narrowed types (discriminated union on `type`)
+  - `consts.ts` — query keys: `{ all: ['items'], byType: ['items', type], byId: ['items', id], byDate: ['items', 'date', date], byTag: ['items', 'tag', tagId] }`
+  - `server.ts` — unified CRUD server functions:
+    - `fetchItems(userId, { type?, date?, tagId?, completed?, parentId?, page?, limit? })` — flexible query with type/date/tag filters
+    - `fetchItem(userId, itemId)` — single item with tags + metadata
+    - `createItem({ type, title, content?, date?, tagIds?, parentItemId? })` — creates item + itemTags, auto-generates prefixed ID
+    - `updateItem({ id, ...fields, tagIds? })` — tag sync in transaction
+    - `deleteItem(itemId)` — hard delete (CASCADE handles tags + metadata)
+    - `completeItem(itemId)` — toggle dateCompleted (tasks only)
+    - `reorderItems(itemIds)` — batch reorder
+  - `queries.ts` — React Query option factories wrapping server functions
+  - `mutations.ts` — React Query mutations with optimistic updates
+- [ ] Update `src/features/tasks/` — thin adapter layer over items:
+  - `server.ts` — task-specific server functions that call unified `fetchItems` with `type: 'task'`:
+    - `fetchTasks`, `fetchTasksForDate`, `fetchBacklogTasks`, `fetchTasksByTag`, `fetchCompletedTasks`, etc.
+    - These delegate to `fetchItems` with appropriate filters — keeps route loaders and queries unchanged
+  - `types.ts` — `Task` type (narrowed from `Item` where `type === 'task'`)
+  - `queries.ts` / `mutations.ts` — keep existing query keys + function signatures, rewire to unified layer
+  - Existing routes and components continue importing from `features/tasks/` — no route changes needed
+- [ ] Update `src/features/notes/` — same thin adapter pattern:
+  - `server.ts` — note-specific functions delegating to unified layer with `type: 'note'`
+  - `types.ts` — `Note` type narrowed from `Item`
+  - `queries.ts` / `mutations.ts` — rewire to unified layer
+  - `searchNotes` — full-text search on items where `type = 'note'`, using content + title + metadata keywords
+- [ ] Create `src/features/events/` — new adapter for event items:
+  - `types.ts` — `Event` type narrowed from `Item` where `type === 'event'`
+  - `server.ts` — event-specific functions: `fetchEvents`, `fetchEventsByTag`, etc.
+  - `queries.ts` / `mutations.ts`
+
+### 8D: Update Components
+
+- [ ] Update `src/components/TaskItem.tsx` — import `Task` from updated types (no visual changes)
+- [ ] Update `src/components/TaskDialog.tsx` — use updated create/update mutations
+- [ ] Update `src/components/NoteItem.tsx` — import `Note` from updated types
+- [ ] Update `src/components/NoteDialog.tsx` — use updated mutations
+- [ ] Update `src/components/SubtaskList.tsx` — uses items with `parentItemId`
+- [ ] Update `src/components/DayView.tsx` — single query for all items on date, render by type
+- [ ] Update `src/components/SortableTaskList.tsx` / `SortableList.tsx` — work with unified item types
+- [ ] Update `src/components/TagMultiSelect.tsx` — uses `itemTags` (no visible change)
+
+### 8E: Update Routes
+
+- [ ] Update all route loaders to use new query options:
+  - `/day/$date` — fetch items for date (all types)
+  - `/backlog` — fetch items where type='task' and date is null
+  - `/notes` — fetch items where type='note', paginated
+  - `/tags` — unchanged (tags table didn't change)
+  - `/tag/$tagId` — fetch items by tag (all types in one query)
+- [ ] All routes keep their current paths and visual layouts
+- [ ] Verify route loaders use `ensureQueryData` with new query option factories
+
+### 8F: Testing & Verification
+
+- [ ] Update MSW handlers in `src/tests/mock/handlers.ts` for new data shapes
+- [ ] Update existing unit tests — rewire to unified item types
+- [ ] Run data migration on real dev database — verify all tasks, notes, tags preserved
+- [ ] **Verify**: `pnpm typecheck` passes — zero errors
+- [ ] **Verify**: `pnpm test` passes — all unit tests green
+- [ ] **Verify**: `pnpm test:e2e` passes — all existing E2E tests green (tasks, notes, tags, backlog, subtasks, navigation)
+- [ ] **Verify**: `pnpm db:seed` works with new schema
+
+### Decisions
+
+- **Unified `items` table** — structural clarity traded for behavioral complexity (`if type === 'task'` branches), but reduces schema from 6 tables + 3 junctions to 3 tables + 1 junction
+- **Thin adapter layers** — `features/tasks/` and `features/notes/` remain as facades. Routes and components don't know about the unified table — they import from the same feature modules as before
+- **Keep prefixed IDs** — `tsk_`, `nte_`, `evt_` prefixes on `items.id` make type identifiable from ID alone (useful for debugging, URLs, logging)
+- **`dateUpdated` added to tasks** — tasks previously lacked this; migration backfills with `dateCreated`
+- **`sortOrder` standardized to text** — notes used integer, tasks used text (fractional indexing). Migration converts note sort orders to text
+- **`title` is NOT NULL** — notes that had null titles get `'Untitled'` during migration. AI can still overwrite `'Untitled'`
+- **Drop old tables in same migration** — data volume is small, migration is tested locally first, rollback is a re-seed
+
+### Outputs
+
+- `src/db/schema.ts` — `items`, `itemTags`, `itemMetadata` tables + relations (old tables removed)
+- `src/features/items/` — types, consts, server, queries, mutations (new shared base layer)
+- `src/features/tasks/` — updated to delegate to items layer
+- `src/features/notes/` — updated to delegate to items layer
+- `src/features/events/` — new adapter for event items
+- Drizzle migration: data migration SQL + table drops
+- Updated: components, routes, MSW handlers, seed data, tests
+
+---
+
+## Phase 9: Reminders & Notifications
+
+> Recurring and one-off reminders with system notifications, snooze, and task generation — built on the unified items architecture. Event items (type `'event'`) are the "what" — schedules are the "when".
+
+### Key Concepts
+
+- **Event item** — an item with `type: 'event'`. Stands on its own in the reminders page. "Team standup" or "Take a break".
+- **Schedule** — a timing attachment on any item. Defines when to fire (reminderTime), recurrence (RRULE), and behavior (notify only vs clone-as-task).
+- **`cloneOnFire`** — when a schedule fires with `cloneOnFire: true`, it creates a new task item with the parent item's title/tags and `date = today`. "Water plants every 3 days" → event item + schedule with cloneOnFire → fresh completable task each time.
+- **Any item can have a schedule** — set a reminder on a task ("remind me about this task tomorrow"), on a note ("review this note Friday"), or on an event (the default — standalone timed notification).
+
+### 9A: Database — Schedules
+
+- [ ] Add to `src/db/schema.ts`:
+  - `schedules`: id (`sch_` prefix), itemId (text FK → items.id CASCADE), reminderTime (text NOT NULL — ISO datetime, next scheduled fire), rrule (text, nullable — iCal RRULE string), snoozedUntil (text, nullable — overrides reminderTime temporarily), cloneOnFire (boolean NOT NULL, default false — if true, creates a task item when fired), status (`active` | `snoozed` | `dismissed` | `completed`), dateCreated (text), dateUpdated (text)
+  - `scheduleHistory`: id (`shx_` prefix), scheduleId (text FK → schedules.id CASCADE), firedAt (text NOT NULL — ISO datetime), action (`notified` | `task_created` | `snoozed` | `dismissed`), createdItemId (text, nullable — FK → items.id SET NULL, the cloned task)
+  - `pushSubscriptions`: id (text PK), userId (text NOT NULL), endpoint (text NOT NULL — Web Push endpoint URL), p256dh (text NOT NULL — client public key), auth (text NOT NULL — auth secret), dateCreated (text NOT NULL)
+- [ ] Add relations: update `itemsRelations` to include `many(schedules)`. Add `schedulesRelations` (one item, many history). Add `scheduleHistoryRelations`.
+- [ ] Generate migration, run it
+- [ ] Update `src/db/seed.ts` — sample schedules: one-off event, recurring event with cloneOnFire, reminder on an existing task, reminder on a note
+
+### 9B: RRULE Engine & Recurrence Logic
+
+- [ ] Install `rrule` npm package — iCal RRULE parsing, serialization, and next-occurrence calculation
+- [ ] Create `src/features/schedules/recurrence.ts`:
+  - `getNextOccurrence(rruleStr, after?)` — calculate next fire time from RRULE
+  - `getOccurrences(rruleStr, from, to)` — list occurrences in a date range (for calendar preview)
+  - `buildRRule(pattern)` — construct RRULE string from UI-friendly pattern object
+  - `describeRRule(rruleStr)` — human-readable description ("Every Monday and Wednesday", "Every 3 days")
+- [ ] Supported patterns via UI:
+  - **Daily** — every day, or every N days
+  - **Weekly** — specific days of week (Mon, Wed, Fri), every N weeks
+  - **Monthly** — specific day of month (1st, 15th), every N months
+  - **Custom interval** — every N days/weeks/months
+  - **Raw RRULE** — advanced text input for power users (validated on save)
+- [ ] When a recurring schedule fires:
+  1. Execute the action (notify, or clone item as task if `cloneOnFire`)
+  2. Log to `scheduleHistory`
+  3. Calculate next occurrence from RRULE
+  4. Update `reminderTime` to next occurrence
+  5. If RRULE has a COUNT/UNTIL and is exhausted → set status to `completed`
+
+### 9C: Server Functions
+
+- [ ] Create `src/features/schedules/` — types.ts, consts.ts, server.ts, queries.ts, mutations.ts
+- [ ] CRUD in `src/features/schedules/server.ts`:
+  - `fetchSchedules(userId)` — all active schedules with their items, ordered by reminderTime ASC
+  - `fetchUpcomingSchedules(userId, limit?)` — active where reminderTime > now, chronological
+  - `fetchPastSchedules(userId, { page, limit })` — paginated history from `scheduleHistory`, ordered by firedAt DESC
+  - `fetchRecurringSchedules(userId)` — where rrule is not null
+  - `fetchSchedulesForItem(itemId)` — all schedules attached to an item
+  - `fetchSchedulesByTag(userId, tagId)` — schedules whose items have a specific tag (JOIN items → itemTags)
+  - `createSchedule({ itemId, reminderTime, rrule?, cloneOnFire? })` — attach schedule to item
+  - `updateSchedule({ id, reminderTime?, rrule?, cloneOnFire? })` — update timing/behavior
+  - `deleteSchedule(scheduleId)` — hard delete
+  - `snoozeSchedule(scheduleId, duration)` — set snoozedUntil: 5m, 15m, 1h, tomorrow 9am. Status → `snoozed`
+  - `dismissSchedule(scheduleId)` — one-off: status → `dismissed`. Recurring: advance to next occurrence
+  - `fireSchedule(scheduleId)` — execute:
+    - If `cloneOnFire` → create new task item with parent's title + tags, `date = today`. Log as `task_created` with createdItemId
+    - If not `cloneOnFire` → log as `notified`
+    - If recurring → calculate and set next occurrence
+    - If one-off → status → `completed`
+- [ ] Update event server functions to create item + schedule in one transaction:
+  - `createEventWithSchedule({ title, content?, date?, tagIds?, reminderTime, rrule?, cloneOnFire? })` — convenience function for the Reminder Dialog
+
+### 9D: Web Push Notifications
+
+- [ ] Generate VAPID key pair (one-time setup, store in env vars)
+- [ ] Install `web-push` npm package
+- [ ] Add env vars to `src/config/env.server.ts`:
+  - `VAPID_PUBLIC_KEY` — public VAPID key (also exposed client-side)
+  - `VAPID_PRIVATE_KEY` — private VAPID key (server-only)
+  - `VAPID_SUBJECT` — mailto: or URL identifier
+- [ ] Add `VAPID_PUBLIC_KEY` to `src/config/env.client.ts` (needed for push subscription)
+- [ ] Server functions for push subscriptions:
+  - `subscribePush({ endpoint, p256dh, auth })` — save to `pushSubscriptions`
+  - `unsubscribePush(endpoint)` — remove subscription
+- [ ] Create `src/features/schedules/push.ts` — `sendPushNotification(userId, { title, body, url? })` using `web-push`
+
+### 9E: Notification Scheduler
+
+- [ ] Create `src/features/schedules/scheduler.ts` — server-side schedule checker:
+  - Runs on an interval (every 30s) checking for due schedules
+  - Query: `WHERE (reminderTime <= now OR snoozedUntil <= now) AND status IN ('active', 'snoozed')`
+  - For each due schedule: call `fireSchedule()`, then `sendPushNotification()`
+  - Handles missed schedules (e.g. server was down) — fires immediately on next check
+- [ ] Integrate scheduler startup into app bootstrap (server-side only, starts when server starts)
+- [ ] In-app foreground detection:
+  - If app is focused when schedule fires → show sonner toast with title, snooze/dismiss actions
+  - If app is in background → Web Push notification (system-level)
+  - Use `document.visibilityState` or `focus`/`blur` events to determine foreground state
+- [ ] Service Worker fallback:
+  - SW registers a periodic sync (where supported) as backup
+  - On `push` event → show notification regardless of app state
+  - Notification click → `clients.openWindow()` or `client.focus()` + navigate
+
+### 9F: UI Components
+
+- [ ] Build `src/components/ReminderDialog.tsx` — create/edit reminder (creates event item + schedule):
+  - **Title** (text input, required)
+  - **Description** (textarea, optional → stored as `content`)
+  - **Generates task** toggle (checkbox icon) — sets `cloneOnFire` on schedule. Explanation text: "Creates a new task each time this fires"
+  - **Date & Time** picker (required — `reminderTime` on schedule)
+  - **Recurrence picker** (`RecurrencePicker` sub-component):
+    - Preset buttons: None, Daily, Weekly, Monthly, Custom
+    - Weekly → day-of-week checkboxes (Mon–Sun)
+    - Monthly → day-of-month select
+    - Custom → interval number + unit (days/weeks/months)
+    - Advanced toggle → raw RRULE text input with validation
+    - Human-readable preview: "Every Monday and Wednesday" / "Every 3 days"
+  - **Tags** — `TagMultiSelect` (reused)
+  - On save: create event item + schedule in one call, request push permission if not granted
+- [ ] Build `src/components/ReminderItem.tsx` — list item for reminders page:
+  - Bell icon (plain event) or checkbox-clock icon (cloneOnFire)
+  - Title as primary text
+  - Next occurrence datetime (relative: "in 2 hours", "tomorrow at 9am")
+  - Recurrence badge if recurring (human-readable: "Weekly · Mon, Wed")
+  - Tag badges (same styling as TaskItem)
+  - Actions: Edit, Snooze dropdown (5m, 15m, 1h, tomorrow), Dismiss/Complete, Delete
+  - Missed indicator for past-due (red dot or "Missed" badge)
+- [ ] Build `RecurrencePicker` component — embedded in ReminderDialog
+- [ ] Build `SnoozeMenu` component — dropdown with preset options (5min, 15min, 1hr, Tomorrow 9am)
+- [ ] Push permission prompt component — inline banner on /reminders if notifications not granted
+- [ ] Add "Set Reminder" button to `TaskDialog.tsx`:
+  - Inline time/recurrence fields, or link to ReminderDialog with item pre-linked
+  - Creates a schedule attached to the task item (no new item created)
+- [ ] Add "Set Reminder" button to `NoteDialog.tsx` — same pattern, schedule attached to note item
+
+### 9G: Routes & Navigation
+
+- [ ] Create `/reminders` route (`src/routes/_app/reminders.tsx`):
+  - **Tabs or sections**: Upcoming | Past | Recurring
+  - **Upcoming**: chronological list of event items with active schedules, grouped by day (Today, Tomorrow, This Week, Later)
+  - **Past**: paginated list from scheduleHistory (fired schedules with timestamps and actions taken)
+  - **Recurring**: management view — all items with recurring schedules, RRULE descriptions, next occurrence, pause/edit/delete
+  - **Search & filter**: tag filter via TagMultiSelect, text search on title/description
+  - **"+ New Reminder"** button → ReminderDialog
+  - Page head: `title: "Reminders - whatIdid"`
+  - Route loader: `ensureQueryData` for upcoming schedules
+- [ ] Update `src/routes/_app.tsx`:
+  - Add "Reminders" to `navItems` array: `{ to: '/reminders', label: 'Reminders' }`
+  - Add reminder dialog state to AppLayoutContext (reminderDialogOpen, editingEvent, handleOpenReminderDialog)
+  - Add keyboard shortcut: Cmd/Ctrl+R → open ReminderDialog
+- [ ] Update `src/routes/_app/tag/$tagId.tsx`:
+  - Events with schedules already appear via `fetchItems(type: 'event', tagId)` — render with `ReminderItem`
+  - Items with schedules (tasks/notes that have reminders) show a small bell indicator
+- [ ] Update `src/components/AppLayoutContext.tsx`:
+  - Export `handleOpenReminderDialog` in layout context
+
+### 9H: Service Worker Setup
+
+- [ ] Create `public/notification-sw.js` — dedicated notification service worker (separate from MSW):
+  - `push` event → `self.registration.showNotification(data.title, { body, icon, badge, data: { url } })`
+  - `notificationclick` → `clients.openWindow(event.notification.data.url)` or focus existing window
+- [ ] Create `src/features/schedules/sw-registration.ts`:
+  - Register notification service worker on app load
+  - Request notification permission (`Notification.requestPermission`)
+  - Subscribe to push (`registration.pushManager.subscribe` with VAPID public key)
+  - Send subscription to server (`subscribePush`)
+  - Handle permission denied gracefully (show in-app-only mode explanation)
+- [ ] Permission state management:
+  - Track `Notification.permission` state in React context or hook
+  - Show permission prompt banner on `/reminders` if permission is `default`
+  - Degrade gracefully to in-app-only toasts if permission is `denied`
+
+### 9I: Testing & Verification
+
+- [ ] Unit tests:
+  - `src/features/schedules/recurrence.test.ts` — RRULE parsing, next occurrence, human descriptions
+  - `src/features/schedules/mutations.test.ts` — create, snooze, dismiss, fire (with cloneOnFire task generation)
+  - `src/features/schedules/push.test.ts` — push notification payload construction
+- [ ] E2E tests: `e2e/reminders.spec.ts`:
+  - Create a one-off event, verify it appears in upcoming list
+  - Create a recurring event with cloneOnFire, verify recurrence description
+  - Snooze a schedule, verify state change
+  - Dismiss a schedule, verify it moves to past
+  - Set reminder on a task from TaskDialog, verify schedule attached
+  - Filter reminders by tag
+  - Navigate to /reminders from nav
+- [ ] **Verify**: `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` all pass
+- [ ] **Verify**: `pnpm db:seed` creates sample events with schedules and history
+- [ ] **Verify**: Push notifications fire in Chromium (Playwright can't test system notifications, but verify subscription flow)
+
+### Decisions
+
+- **Events are items** — `type: 'event'` in the unified items table. No separate entity. Tags, dates, and all item features come free
+- **Schedules are orthogonal** — any item can have schedules. Event + schedule = standalone reminder. Task + schedule = "remind me about this task". Item + schedule + cloneOnFire = recurring task generation
+- **`cloneOnFire` replaces "reminder type"** — instead of `event` vs `task` reminder types, it's a boolean on the schedule. Simpler, more flexible
+- **RRULE standard** — iCal-compatible recurrence rules via `rrule` package. Future-proof, powerful, widely understood
+- **`scheduleHistory` for audit trail** — every fire/snooze/dismiss logged. Enables "past" view without losing data as recurring schedules advance
+- **Server-side scheduler + SW fallback** — server polls every 30s for reliability, SW handles background push delivery
+- **Separate service worker** — `notification-sw.js` is distinct from MSW's `mockServiceWorker.js`
+- **VAPID keys in env vars** — standard Web Push auth, generated once per deployment
+- **Snooze presets only** — 5m, 15m, 1h, tomorrow 9am. No custom time picker
+- **Reminder Dialog creates event + schedule** — one dialog, one operation. For adding a reminder to an existing task/note, the TaskDialog/NoteDialog inline a schedule picker
+
+### Outputs
+
+- `src/db/schema.ts` — `schedules`, `scheduleHistory`, `pushSubscriptions` tables + relations
+- `src/features/schedules/` — types, consts, server, queries, mutations, recurrence, push, scheduler, sw-registration
+- `src/features/events/` — updated with schedule integration
+- `src/components/ReminderDialog.tsx`, `ReminderItem.tsx`, `RecurrencePicker.tsx`, `SnoozeMenu.tsx`
+- `src/routes/_app/reminders.tsx`
+- `public/notification-sw.js`
+- Updated: `_app.tsx`, `AppLayoutContext.tsx`, `TaskDialog.tsx`, `NoteDialog.tsx`, `tag/$tagId.tsx`, `seed.ts`
+- Dependencies: `rrule`, `web-push`
+
+---
+
+## Phase 10: Multi-User & Auth (Future)
 
 > Add authentication so it can be shared or self-hosted for multiple users.
 
@@ -462,23 +837,47 @@
 
 ### Database Schema (ERD Summary)
 
+**After Phase 8 migration (unified model):**
+
+```
+items ──── itemTags ──── tags
+  │
+  ├── itemMetadata (one-to-one, AI keywords + future embeddings)
+  │
+  ├── schedules (one-to-many, reminder timing + recurrence)
+  │     └── scheduleHistory (audit: fired, snoozed, dismissed, task_created)
+  │
+  └── self-reference (parentItemId → items.id for subtasks)
+
+pushSubscriptions (per user, for Web Push delivery)
+
+Item types: 'task' | 'note' | 'event'
+- task: completable, has subtasks, appears in day view + backlog
+- note: content-first, AI-processed, appears in notes page + day view
+- event: standalone reminder entry, appears in reminders page
+
+All types share: title, content, date, tags, metadata, schedules
+Behavior differs by type column + conditional UI
+```
+
+**Before Phase 8 (legacy, for reference):**
+
 ```
 tasks ──── taskTags ──── tags ──── noteTags ──── notes
                                                    │
                                               noteMetadata
-
-tasks self-reference (parentTaskId → tasks.id) for subtasks
-notes + tasks share the same tags pool via separate junction tables
-noteMetadata is one-to-one with notes (AI-generated keywords, future embeddings)
 ```
 
 ### Environment Variables
 
-| Variable       | Scope  | Phase | Description                                                                          |
-| -------------- | ------ | ----- | ------------------------------------------------------------------------------------ |
-| `DATABASE_URL` | Server | 3     | PostgreSQL connection string (e.g., `postgres://whatidid:whatidid@db:5432/whatidid`) |
-| `AI_PROVIDER`  | Server | 7     | `xai` (default), `openai`, `ollama`, `anthropic`                                     |
-| `AI_API_KEY`   | Server | 7     | xAI API key for Grok (optional — AI degrades gracefully)                             |
+| Variable            | Scope  | Phase | Description                                                                          |
+| ------------------- | ------ | ----- | ------------------------------------------------------------------------------------ |
+| `DATABASE_URL`      | Server | 3     | PostgreSQL connection string (e.g., `postgres://whatidid:whatidid@db:5432/whatidid`) |
+| `AI_PROVIDER`       | Server | 7     | `xai` (default), `openai`, `ollama`, `anthropic`                                     |
+| `AI_API_KEY`        | Server | 7     | xAI API key for Grok (optional — AI degrades gracefully)                             |
+| `VAPID_PUBLIC_KEY`  | Both   | 9     | Web Push VAPID public key (server signs, client subscribes)                          |
+| `VAPID_PRIVATE_KEY` | Server | 9     | Web Push VAPID private key (server-only, never exposed to client)                    |
+| `VAPID_SUBJECT`     | Server | 9     | VAPID subject — `mailto:` email or URL identifying the app                           |
 
 ### New npm Packages by Phase
 
@@ -489,4 +888,6 @@ noteMetadata is one-to-one with notes (AI-generated keywords, future embeddings)
 | 4     | None (CSS-only — uses existing Tailwind CSS 4 `@theme` system) |
 | 5     | `sonner` (toast notifications)                                 |
 | 7     | `openai`, `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/pm` |
-| 8     | TBD (auth library)                                             |
+| 8     | None (schema migration + code refactor only)                   |
+| 9     | `rrule`, `web-push`                                            |
+| 10    | TBD (auth library)                                             |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-**whatIdid** is a personal task tracker and AI-powered notes system. Built with React 19, TypeScript, and TanStack Start as a full-stack framework. The app is being developed iteratively — check `.github/PLAN.md` for the current phase.
+**whatIdid** is a personal task tracker, notes system, and reminder app with AI-powered features. Built with React 19, TypeScript, and TanStack Start as a full-stack framework. The app uses a **unified `items` table** — tasks, notes, and events (reminders) are all items differentiated by a `type` column. Schedules (reminder timing, recurrence) attach to any item. Check `.github/PLAN.md` for the current phase.
 
 ### Tech Stack
 
@@ -62,10 +62,18 @@ export const myFunction = createServerFn({ method: "GET" })
 - Drizzle client singleton in `src/db/index.ts`
 - Migrations managed via `drizzle-kit` (`pnpm db:generate`, `pnpm db:migrate`)
 - All tables include `userId` column (multi-user ready, hardcoded '1' for now)
+- **Unified `items` table** — single table with `type` column (`task` | `note` | `event`). One `itemTags` junction table, one `itemMetadata` table. `schedules` table attaches to any item for reminder timing and recurrence.
+- **ID prefixes** — `tsk_` (task), `nte_` (note), `evt_` (event), `sch_` (schedule), `shx_` (schedule history)
+- **Thin adapters** — `features/tasks/`, `features/notes/`, `features/events/` are facade layers that delegate to `features/items/` with type filters
 
 ## File & Folder Organization
 
-- `src/features/{domain}/` — Feature modules (tasks, tags, notes, ai)
+- `src/features/{domain}/` — Feature modules (items, tasks, tags, notes, events, schedules, ai)
+- `src/features/items/` — Shared base layer: unified CRUD for all item types
+- `src/features/tasks/` — Thin adapter over items (type='task' filter)
+- `src/features/notes/` — Thin adapter over items (type='note' filter)
+- `src/features/events/` — Thin adapter over items (type='event' filter)
+- `src/features/schedules/` — Reminder timing, recurrence (RRULE), push notifications
 - `src/components/` — Shared UI components
 - `src/components/ui/` — Primitive UI components (button, dialog, input, etc.)
 - `src/routes/` — File-based routes (TanStack Router)
@@ -127,7 +135,7 @@ export const myFunction = createServerFn({ method: "GET" })
 
 - All data mutations go through server functions — never call the DB from client code
 - Use Zod for input validation on all server functions
-- React Query keys follow the pattern: `{ all: [domain], byId: [domain, id] }`
+- React Query keys follow the pattern: `{ all: [domain], byType: [domain, type], byId: [domain, id] }`
 - Optimistic updates are the default for mutations affecting UI state
 - Components that need hydration-awareness use `useEffect` state guard
 - Drag-and-drop components use dnd-kit with `useSortable` hook per item

--- a/drizzle/0004_unified_items.sql
+++ b/drizzle/0004_unified_items.sql
@@ -1,0 +1,130 @@
+-- Migration: Unified Items Architecture
+-- Migrates separate tasks/notes tables into a single items table.
+-- Preserves all existing data.
+
+-- 1. Create new tables
+CREATE TABLE IF NOT EXISTS "items" (
+  "id" text PRIMARY KEY NOT NULL,
+  "type" text NOT NULL,
+  "title" text NOT NULL,
+  "content" text,
+  "date" text,
+  "date_completed" text,
+  "parent_item_id" text,
+  "sort_order" text NOT NULL DEFAULT 'a0',
+  "user_id" text NOT NULL,
+  "date_created" text NOT NULL,
+  "date_updated" text NOT NULL,
+  FOREIGN KEY ("parent_item_id") REFERENCES "items"("id")
+);
+
+CREATE TABLE IF NOT EXISTS "item_tags" (
+  "item_id" text NOT NULL REFERENCES "items"("id") ON DELETE CASCADE,
+  "tag_id" text NOT NULL REFERENCES "tags"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("item_id", "tag_id")
+);
+
+CREATE TABLE IF NOT EXISTS "item_metadata" (
+  "item_id" text PRIMARY KEY NOT NULL REFERENCES "items"("id") ON DELETE CASCADE,
+  "keywords" text,
+  "embedding" bytea
+);
+
+CREATE TABLE IF NOT EXISTS "schedules" (
+  "id" text PRIMARY KEY NOT NULL,
+  "item_id" text NOT NULL REFERENCES "items"("id") ON DELETE CASCADE,
+  "reminder_time" text NOT NULL,
+  "rrule" text,
+  "snoozed_until" text,
+  "clone_on_fire" boolean NOT NULL DEFAULT false,
+  "status" text NOT NULL DEFAULT 'active',
+  "date_created" text NOT NULL,
+  "date_updated" text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "schedule_history" (
+  "id" text PRIMARY KEY NOT NULL,
+  "schedule_id" text NOT NULL REFERENCES "schedules"("id") ON DELETE CASCADE,
+  "fired_at" text NOT NULL,
+  "action" text NOT NULL,
+  "created_item_id" text REFERENCES "items"("id") ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS "push_subscriptions" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "endpoint" text NOT NULL,
+  "p256dh" text NOT NULL,
+  "auth" text NOT NULL,
+  "date_created" text NOT NULL
+);
+
+-- 2. Copy tasks → items (root tasks first, then subtasks)
+-- Root tasks (no parent)
+INSERT INTO "items" ("id", "type", "title", "content", "date", "date_completed", "parent_item_id", "sort_order", "user_id", "date_created", "date_updated")
+SELECT
+  "id",
+  'task',
+  "title",
+  "notes",
+  "start_date",
+  "date_completed",
+  NULL,
+  "sort_order",
+  "user_id",
+  "date_created",
+  COALESCE("date_completed", "date_created")
+FROM "tasks"
+WHERE "parent_task_id" IS NULL;
+
+-- Subtasks (parent already inserted)
+INSERT INTO "items" ("id", "type", "title", "content", "date", "date_completed", "parent_item_id", "sort_order", "user_id", "date_created", "date_updated")
+SELECT
+  "id",
+  'task',
+  "title",
+  "notes",
+  "start_date",
+  "date_completed",
+  "parent_task_id",
+  "sort_order",
+  "user_id",
+  "date_created",
+  COALESCE("date_completed", "date_created")
+FROM "tasks"
+WHERE "parent_task_id" IS NOT NULL;
+
+-- 3. Copy notes → items
+INSERT INTO "items" ("id", "type", "title", "content", "date", "date_completed", "parent_item_id", "sort_order", "user_id", "date_created", "date_updated")
+SELECT
+  "id",
+  'note',
+  COALESCE("title", 'Untitled'),
+  "content",
+  "date",
+  NULL,
+  NULL,
+  CAST("sort_order" AS text),
+  "user_id",
+  "date_created",
+  "date_updated"
+FROM "notes";
+
+-- 4. Copy task_tags → item_tags
+INSERT INTO "item_tags" ("item_id", "tag_id")
+SELECT "task_id", "tag_id" FROM "task_tags";
+
+-- 5. Copy note_tags → item_tags
+INSERT INTO "item_tags" ("item_id", "tag_id")
+SELECT "note_id", "tag_id" FROM "note_tags";
+
+-- 6. Copy note_metadata → item_metadata
+INSERT INTO "item_metadata" ("item_id", "keywords", "embedding")
+SELECT "note_id", "keywords", "embedding" FROM "note_metadata";
+
+-- 7. Drop old tables (order matters for FK constraints)
+DROP TABLE IF EXISTS "note_metadata" CASCADE;
+DROP TABLE IF EXISTS "note_tags" CASCADE;
+DROP TABLE IF EXISTS "task_tags" CASCADE;
+DROP TABLE IF EXISTS "notes" CASCADE;
+DROP TABLE IF EXISTS "tasks" CASCADE;

--- a/drizzle/0005_moaning_mathemanic.sql
+++ b/drizzle/0005_moaning_mathemanic.sql
@@ -1,4 +1,5 @@
 -- Add ON DELETE CASCADE to items.parent_item_id self-reference
+-- 0004 created the FK inline (unnamed), so Postgres named it "items_parent_item_id_fkey"
+ALTER TABLE "items" DROP CONSTRAINT IF EXISTS "items_parent_item_id_fkey";--> statement-breakpoint
 ALTER TABLE "items" DROP CONSTRAINT IF EXISTS "items_parent_item_id_items_id_fk";--> statement-breakpoint
 ALTER TABLE "items" ADD CONSTRAINT "items_parent_item_id_items_id_fk" FOREIGN KEY ("parent_item_id") REFERENCES "public"."items"("id") ON DELETE cascade ON UPDATE no action;
-ALTER TABLE "schedules" ADD CONSTRAINT "schedules_item_id_items_id_fk" FOREIGN KEY ("item_id") REFERENCES "public"."items"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0005_moaning_mathemanic.sql
+++ b/drizzle/0005_moaning_mathemanic.sql
@@ -1,0 +1,4 @@
+-- Add ON DELETE CASCADE to items.parent_item_id self-reference
+ALTER TABLE "items" DROP CONSTRAINT IF EXISTS "items_parent_item_id_items_id_fk";--> statement-breakpoint
+ALTER TABLE "items" ADD CONSTRAINT "items_parent_item_id_items_id_fk" FOREIGN KEY ("parent_item_id") REFERENCES "public"."items"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "schedules" ADD CONSTRAINT "schedules_item_id_items_id_fk" FOREIGN KEY ("item_id") REFERENCES "public"."items"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,784 @@
+{
+  "id": "94bfa07e-96c8-493a-921e-f26a2bcfdff3",
+  "prevId": "927757e4-108f-49e8-90bd-9ab27ea574d8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.item_metadata": {
+      "name": "item_metadata",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_metadata_item_id_items_id_fk": {
+          "name": "item_metadata_item_id_items_id_fk",
+          "tableFrom": "item_metadata",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tags": {
+      "name": "item_tags",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_tags_item_id_items_id_fk": {
+          "name": "item_tags_item_id_items_id_fk",
+          "tableFrom": "item_tags",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_tags_tag_id_tags_id_fk": {
+          "name": "item_tags_tag_id_tags_id_fk",
+          "tableFrom": "item_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "item_tags_item_id_tag_id_pk": {
+          "name": "item_tags_item_id_tag_id_pk",
+          "columns": [
+            "item_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_item_id": {
+          "name": "parent_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_parent_item_id_items_id_fk": {
+          "name": "items_parent_item_id_items_id_fk",
+          "tableFrom": "items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "parent_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_metadata": {
+      "name": "note_metadata",
+      "schema": "",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_metadata_note_id_notes_id_fk": {
+          "name": "note_metadata_note_id_notes_id_fk",
+          "tableFrom": "note_metadata",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_tags": {
+      "name": "note_tags",
+      "schema": "",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_tags_note_id_notes_id_fk": {
+          "name": "note_tags_note_id_notes_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_tags_tag_id_tags_id_fk": {
+          "name": "note_tags_tag_id_tags_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_tags_note_id_tag_id_pk": {
+          "name": "note_tags_note_id_tag_id_pk",
+          "columns": [
+            "note_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_history": {
+      "name": "schedule_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_item_id": {
+          "name": "created_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_history_schedule_id_schedules_id_fk": {
+          "name": "schedule_history_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_history",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_history_created_item_id_items_id_fk": {
+          "name": "schedule_history_created_item_id_items_id_fk",
+          "tableFrom": "schedule_history",
+          "tableTo": "items",
+          "columnsFrom": [
+            "created_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_on_fire": {
+          "name": "clone_on_fire",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_updated": {
+          "name": "date_updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedules_item_id_items_id_fk": {
+          "name": "schedules_item_id_items_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_tags": {
+      "name": "task_tags",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_tags_task_id_tasks_id_fk": {
+          "name": "task_tags_task_id_tasks_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_tags_tag_id_tags_id_fk": {
+          "name": "task_tags_tag_id_tags_id_fk",
+          "tableFrom": "task_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_tags_task_id_tag_id_pk": {
+          "name": "task_tags_task_id_tag_id_pk",
+          "columns": [
+            "task_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_created": {
+          "name": "date_created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_parent_task_id_tasks_id_fk": {
+          "name": "tasks_parent_task_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776883200000,
       "tag": "0004_unified_items",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776717317128,
+      "tag": "0005_moaning_mathemanic",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776675364948,
       "tag": "0003_purple_synch",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776883200000,
+      "tag": "0004_unified_items",
+      "breakpoints": true
     }
   ]
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [["html"], ["list"]],
+  reporter: [["html", { open: "never" }], ["list"]],
   use: {
     baseURL: "http://localhost:55001",
     trace: "on-first-retry",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -55,7 +55,7 @@ export const items = pgTable(
     foreignKey({
       columns: [table.parentItemId],
       foreignColumns: [table.id],
-    }),
+    }).onDelete("cascade"),
   ],
 );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,10 +1,10 @@
 import {
   pgTable,
   text,
-  integer,
   foreignKey,
   primaryKey,
   customType,
+  boolean,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
@@ -34,8 +34,168 @@ export const tags = pgTable("tags", {
   updatedAt: text("updated_at").notNull(),
 });
 
-// --- Tasks ---
+// --- Items (unified: task | note | event) ---
 
+export const items = pgTable(
+  "items",
+  {
+    id: text("id").primaryKey(),
+    type: text("type").notNull(), // 'task' | 'note' | 'event'
+    title: text("title").notNull(),
+    content: text("content"),
+    date: text("date"),
+    dateCompleted: text("date_completed"),
+    parentItemId: text("parent_item_id"),
+    sortOrder: text("sort_order").notNull().default("a0"),
+    userId: text("user_id").notNull(),
+    dateCreated: text("date_created").notNull(),
+    dateUpdated: text("date_updated").notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.parentItemId],
+      foreignColumns: [table.id],
+    }),
+  ],
+);
+
+// --- Item Tags (junction) ---
+
+export const itemTags = pgTable(
+  "item_tags",
+  {
+    itemId: text("item_id")
+      .notNull()
+      .references(() => items.id, { onDelete: "cascade" }),
+    tagId: text("tag_id")
+      .notNull()
+      .references(() => tags.id, { onDelete: "cascade" }),
+  },
+  (table) => [primaryKey({ columns: [table.itemId, table.tagId] })],
+);
+
+// --- Item Metadata (one-to-one, AI-generated) ---
+
+export const itemMetadata = pgTable("item_metadata", {
+  itemId: text("item_id")
+    .primaryKey()
+    .references(() => items.id, { onDelete: "cascade" }),
+  keywords: text("keywords"),
+  embedding: bytea("embedding"),
+});
+
+// --- Schedules (reminders / recurrence, attached to any item) ---
+
+export const schedules = pgTable("schedules", {
+  id: text("id").primaryKey(),
+  itemId: text("item_id")
+    .notNull()
+    .references(() => items.id, { onDelete: "cascade" }),
+  reminderTime: text("reminder_time").notNull(),
+  rrule: text("rrule"),
+  snoozedUntil: text("snoozed_until"),
+  cloneOnFire: boolean("clone_on_fire").notNull().default(false),
+  status: text("status").notNull().default("active"), // 'active' | 'snoozed' | 'dismissed' | 'completed'
+  dateCreated: text("date_created").notNull(),
+  dateUpdated: text("date_updated").notNull(),
+});
+
+// --- Schedule History ---
+
+export const scheduleHistory = pgTable("schedule_history", {
+  id: text("id").primaryKey(),
+  scheduleId: text("schedule_id")
+    .notNull()
+    .references(() => schedules.id, { onDelete: "cascade" }),
+  firedAt: text("fired_at").notNull(),
+  action: text("action").notNull(), // 'notified' | 'task_created' | 'snoozed' | 'dismissed'
+  createdItemId: text("created_item_id").references(() => items.id, {
+    onDelete: "set null",
+  }),
+});
+
+// --- Push Subscriptions ---
+
+export const pushSubscriptions = pgTable("push_subscriptions", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  endpoint: text("endpoint").notNull(),
+  p256dh: text("p256dh").notNull(),
+  auth: text("auth").notNull(),
+  dateCreated: text("date_created").notNull(),
+});
+
+// =====================
+// Relations
+// =====================
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  itemTags: many(itemTags),
+}));
+
+export const itemsRelations = relations(items, ({ one, many }) => ({
+  parentItem: one(items, {
+    fields: [items.parentItemId],
+    references: [items.id],
+    relationName: "subtasks",
+  }),
+  subtasks: many(items, { relationName: "subtasks" }),
+  itemTags: many(itemTags),
+  metadata: one(itemMetadata, {
+    fields: [items.id],
+    references: [itemMetadata.itemId],
+  }),
+  schedules: many(schedules),
+}));
+
+export const itemTagsRelations = relations(itemTags, ({ one }) => ({
+  item: one(items, {
+    fields: [itemTags.itemId],
+    references: [items.id],
+  }),
+  tag: one(tags, {
+    fields: [itemTags.tagId],
+    references: [tags.id],
+  }),
+}));
+
+export const itemMetadataRelations = relations(itemMetadata, ({ one }) => ({
+  item: one(items, {
+    fields: [itemMetadata.itemId],
+    references: [items.id],
+  }),
+}));
+
+export const schedulesRelations = relations(schedules, ({ one, many }) => ({
+  item: one(items, {
+    fields: [schedules.itemId],
+    references: [items.id],
+  }),
+  history: many(scheduleHistory),
+}));
+
+export const scheduleHistoryRelations = relations(
+  scheduleHistory,
+  ({ one }) => ({
+    schedule: one(schedules, {
+      fields: [scheduleHistory.scheduleId],
+      references: [schedules.id],
+    }),
+    createdItem: one(items, {
+      fields: [scheduleHistory.createdItemId],
+      references: [items.id],
+    }),
+  }),
+);
+
+// =====================
+// Legacy table exports (kept for migration reference, will be removed after migration)
+// =====================
+// These are exported so the migration script can reference them.
+// After running migration 0004, these table definitions and the actual
+// database tables no longer exist.
+
+/** @deprecated Use `items` table */
 export const tasks = pgTable(
   "tasks",
   {
@@ -57,8 +217,7 @@ export const tasks = pgTable(
   ],
 );
 
-// --- Task Tags (junction) ---
-
+/** @deprecated Use `itemTags` table */
 export const taskTags = pgTable(
   "task_tags",
   {
@@ -72,21 +231,19 @@ export const taskTags = pgTable(
   (table) => [primaryKey({ columns: [table.taskId, table.tagId] })],
 );
 
-// --- Notes ---
-
+/** @deprecated Use `items` table */
 export const notes = pgTable("notes", {
   id: text("id").primaryKey(),
   content: text("content").notNull(),
   title: text("title"),
   date: text("date"),
-  sortOrder: integer("sort_order").notNull().default(0),
+  sortOrder: text("sort_order").notNull().default("0"),
   userId: text("user_id").notNull(),
   dateCreated: text("date_created").notNull(),
   dateUpdated: text("date_updated").notNull(),
 });
 
-// --- Note Tags (junction) ---
-
+/** @deprecated Use `itemTags` table */
 export const noteTags = pgTable(
   "note_tags",
   {
@@ -100,8 +257,7 @@ export const noteTags = pgTable(
   (table) => [primaryKey({ columns: [table.noteId, table.tagId] })],
 );
 
-// --- Note Metadata (one-to-one with notes, AI-generated) ---
-
+/** @deprecated Use `itemMetadata` table */
 export const noteMetadata = pgTable("note_metadata", {
   noteId: text("note_id")
     .primaryKey()
@@ -109,59 +265,3 @@ export const noteMetadata = pgTable("note_metadata", {
   keywords: text("keywords"),
   embedding: bytea("embedding"),
 });
-
-// =====================
-// Relations
-// =====================
-
-export const tagsRelations = relations(tags, ({ many }) => ({
-  taskTags: many(taskTags),
-  noteTags: many(noteTags),
-}));
-
-export const tasksRelations = relations(tasks, ({ one, many }) => ({
-  parentTask: one(tasks, {
-    fields: [tasks.parentTaskId],
-    references: [tasks.id],
-    relationName: "subtasks",
-  }),
-  subtasks: many(tasks, { relationName: "subtasks" }),
-  taskTags: many(taskTags),
-}));
-
-export const taskTagsRelations = relations(taskTags, ({ one }) => ({
-  task: one(tasks, {
-    fields: [taskTags.taskId],
-    references: [tasks.id],
-  }),
-  tag: one(tags, {
-    fields: [taskTags.tagId],
-    references: [tags.id],
-  }),
-}));
-
-export const notesRelations = relations(notes, ({ many, one }) => ({
-  noteTags: many(noteTags),
-  metadata: one(noteMetadata, {
-    fields: [notes.id],
-    references: [noteMetadata.noteId],
-  }),
-}));
-
-export const noteTagsRelations = relations(noteTags, ({ one }) => ({
-  note: one(notes, {
-    fields: [noteTags.noteId],
-    references: [notes.id],
-  }),
-  tag: one(tags, {
-    fields: [noteTags.tagId],
-    references: [tags.id],
-  }),
-}));
-
-export const noteMetadataRelations = relations(noteMetadata, ({ one }) => ({
-  note: one(notes, {
-    fields: [noteMetadata.noteId],
-    references: [notes.id],
-  }),
-}));

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -13,11 +13,9 @@ const client = postgres(DATABASE_URL);
 const db = drizzle(client, { schema });
 
 // Clear existing data
-await db.delete(schema.noteMetadata);
-await db.delete(schema.noteTags);
-await db.delete(schema.notes);
-await db.delete(schema.taskTags);
-await db.delete(schema.tasks);
+await db.delete(schema.itemMetadata);
+await db.delete(schema.itemTags);
+await db.delete(schema.items);
 await db.delete(schema.tags);
 
 // Seed sample tasks
@@ -31,124 +29,232 @@ const todayStr = formatDate(today);
 const rootKeys = generateNKeysBetween(null, null, 10);
 const subtaskKeys = generateNKeysBetween(null, null, 2);
 
-const sampleTasks = [
+const sampleItems = [
+  // ── Tasks ──────────────────────────────────────────────────────────
   {
     id: "tsk_001",
+    type: "task",
     title: "Plan Q4 roadmap",
-    notes: "Outline key deliverables and milestones.",
+    content: "Outline key deliverables and milestones.",
     dateCreated: "2025-09-25T09:12:03.000Z",
+    dateUpdated: "2025-09-25T09:12:03.000Z",
     dateCompleted: null,
-    startDate: todayStr,
+    date: todayStr,
     userId: "1",
     sortOrder: rootKeys[0],
+    parentItemId: null,
   },
   {
     id: "tsk_002",
+    type: "task",
     title: "Refactor legacy auth module",
-    notes: "Improve readability and add missing tests.",
+    content: "Improve readability and add missing tests.",
     dateCreated: "2025-09-20T14:31:10.000Z",
+    dateUpdated: "2025-09-20T14:31:10.000Z",
     dateCompleted: null,
-    startDate: todayStr,
+    date: todayStr,
     userId: "1",
     sortOrder: rootKeys[1],
+    parentItemId: null,
   },
   {
     id: "tsk_003",
+    type: "task",
     title: "Write unit tests for task utils",
-    notes: "Focus on edge cases around completion toggling.",
+    content: "Focus on edge cases around completion toggling.",
     dateCreated: "2025-09-29T11:05:47.000Z",
+    dateUpdated: "2025-09-29T11:05:47.000Z",
     dateCompleted: null,
+    date: null,
     userId: "1",
     sortOrder: rootKeys[2],
+    parentItemId: null,
   },
   {
     id: "tsk_004",
+    type: "task",
     title: "Update README deployment section",
-    notes: "Add staging environment notes.",
+    content: "Add staging environment notes.",
     dateCreated: "2025-09-18T08:44:55.000Z",
+    dateUpdated: "2025-09-18T08:44:55.000Z",
     dateCompleted: null,
+    date: null,
     userId: "1",
     sortOrder: rootKeys[3],
+    parentItemId: null,
   },
   {
     id: "tsk_005",
+    type: "task",
     title: "Design notification settings UI",
-    notes: "Keep components accessible with proper ARIA.",
+    content: "Keep components accessible with proper ARIA.",
     dateCreated: "2025-10-01T10:02:11.000Z",
+    dateUpdated: "2025-10-01T10:02:11.000Z",
     dateCompleted: null,
-    startDate: todayStr,
+    date: todayStr,
     userId: "1",
     sortOrder: rootKeys[4],
+    parentItemId: null,
   },
   {
     id: "tsk_006",
+    type: "task",
     title: "Fix timezone bug in date picker",
-    notes: "Occurs when user switches locale mid-session.",
+    content: "Occurs when user switches locale mid-session.",
     dateCreated: "2025-09-30T07:22:39.000Z",
+    dateUpdated: "2025-09-30T07:22:39.000Z",
     dateCompleted: null,
+    date: null,
     userId: "1",
     sortOrder: rootKeys[5],
+    parentItemId: null,
   },
   {
     id: "tsk_007",
+    type: "task",
     title: "Add API error handling tests",
-    notes: "Cover error states (500, 404).",
+    content: "Cover error states (500, 404).",
     dateCreated: "2025-09-27T15:50:33.000Z",
+    dateUpdated: "2025-11-17T17:46:50.189Z",
     dateCompleted: "2025-11-17T17:46:50.189Z",
+    date: null,
     userId: "1",
     sortOrder: rootKeys[6],
+    parentItemId: null,
   },
   {
     id: "tsk_008",
+    type: "task",
     title: "Optimize bundle size",
-    notes: "Investigate code splitting for feature routes.",
+    content: "Investigate code splitting for feature routes.",
     dateCreated: "2025-09-23T09:05:14.000Z",
+    dateUpdated: "2025-09-23T09:05:14.000Z",
     dateCompleted: null,
+    date: null,
     userId: "1",
     sortOrder: rootKeys[7],
+    parentItemId: null,
   },
   {
     id: "tsk_009",
+    type: "task",
     title: "Create productivity tips blog draft",
-    notes: "Reference reputable sources.",
+    content: "Reference reputable sources.",
     dateCreated: "2025-09-26T12:14:57.000Z",
+    dateUpdated: "2026-04-10T12:00:00.000Z",
     dateCompleted: "2026-04-10T12:00:00.000Z",
+    date: null,
     userId: "1",
     sortOrder: rootKeys[8],
+    parentItemId: null,
   },
   {
     id: "tsk_010",
+    type: "task",
     title: "Build task filtering system",
-    notes: "Use client-side filtering first pass.",
+    content: "Use client-side filtering first pass.",
     dateCreated: "2025-10-03T13:43:22.000Z",
+    dateUpdated: "2025-10-03T13:43:22.000Z",
     dateCompleted: null,
+    date: null,
     userId: "1",
     sortOrder: rootKeys[9],
+    parentItemId: null,
   },
   // Subtasks of tsk_001
   {
     id: "tsk_012",
+    type: "task",
     title: "Gather team input on priorities",
-    notes: null,
+    content: null,
     dateCreated: "2025-09-25T09:15:00.000Z",
+    dateUpdated: "2025-09-25T09:15:00.000Z",
     dateCompleted: null,
-    parentTaskId: "tsk_001",
+    date: null,
+    parentItemId: "tsk_001",
     userId: "1",
     sortOrder: subtaskKeys[0],
   },
   {
     id: "tsk_013",
+    type: "task",
     title: "Draft milestone timeline",
-    notes: null,
+    content: null,
     dateCreated: "2025-09-25T09:16:00.000Z",
+    dateUpdated: "2025-10-02T11:00:00.000Z",
     dateCompleted: "2025-10-02T11:00:00.000Z",
-    parentTaskId: "tsk_001",
+    date: null,
+    parentItemId: "tsk_001",
     userId: "1",
     sortOrder: subtaskKeys[1],
   },
+  // ── Notes ──────────────────────────────────────────────────────────
+  {
+    id: "nte_001",
+    type: "note",
+    title: "Jenkins Pipeline Staging Issue",
+    content:
+      "Spoke with Sarah about the Jenkins pipeline failing on staging. She thinks it's a Docker image caching issue. Need to check the build logs.",
+    date: todayStr,
+    dateCompleted: null,
+    parentItemId: null,
+    sortOrder: "0",
+    userId: "1",
+    dateCreated: "2026-04-18T09:30:00.000Z",
+    dateUpdated: "2026-04-18T09:30:00.000Z",
+  },
+  {
+    id: "nte_002",
+    type: "note",
+    title: "Dashboard Redesign Colour Palette",
+    content:
+      "Meeting with design team — agreed on new colour palette for dashboard. Moving away from blue-heavy scheme to more neutral tones with accent colours per feature area.",
+    date: todayStr,
+    dateCompleted: null,
+    parentItemId: null,
+    sortOrder: "1",
+    userId: "1",
+    dateCreated: "2026-04-17T14:15:00.000Z",
+    dateUpdated: "2026-04-17T14:15:00.000Z",
+  },
+  {
+    id: "nte_003",
+    type: "note",
+    title: "Untitled",
+    content:
+      "Idea: add keyboard shortcuts for common actions — Cmd+N for new task, Cmd+Shift+N for new note, Cmd+K for search. Check what VS Code and Linear use for reference.",
+    date: null,
+    dateCompleted: null,
+    parentItemId: null,
+    sortOrder: "0",
+    userId: "1",
+    dateCreated: "2026-04-16T11:00:00.000Z",
+    dateUpdated: "2026-04-16T11:00:00.000Z",
+  },
+  {
+    id: "nte_004",
+    type: "note",
+    title: "Q1 Performance Review Notes",
+    content:
+      "Performance review prep: shipped task system, calendar integration, and drag-drop. Contributed to design system tokens. Mentored two junior devs on React Query patterns.",
+    date: null,
+    dateCompleted: null,
+    parentItemId: null,
+    sortOrder: "1",
+    userId: "1",
+    dateCreated: "2026-04-10T16:45:00.000Z",
+    dateUpdated: "2026-04-15T10:20:00.000Z",
+  },
 ];
 
-await db.insert(schema.tasks).values(sampleTasks);
+// Insert root items first (no parentItemId), then subtasks
+const rootItems = sampleItems.filter((i) => !i.parentItemId);
+const subtaskItems = sampleItems.filter((i) => i.parentItemId);
+
+await db.insert(schema.items).values(rootItems);
+if (subtaskItems.length > 0) {
+  await db.insert(schema.items).values(subtaskItems);
+}
 
 // Seed tags
 await db.insert(schema.tags).values([
@@ -190,103 +296,54 @@ await db.insert(schema.tags).values([
   },
 ]);
 
-// Seed task-tag relationships
-await db.insert(schema.taskTags).values([
-  { taskId: "tsk_001", tagId: "tag_002" },
-  { taskId: "tsk_002", tagId: "tag_002" },
-  { taskId: "tsk_002", tagId: "tag_003" },
-  { taskId: "tsk_003", tagId: "tag_001" },
-  { taskId: "tsk_005", tagId: "tag_001" },
-  { taskId: "tsk_005", tagId: "tag_004" },
-  { taskId: "tsk_006", tagId: "tag_001" },
-  { taskId: "tsk_006", tagId: "tag_003" },
-  { taskId: "tsk_008", tagId: "tag_001" },
-]);
-
-// Seed sample notes
-const sampleNotes = [
-  {
-    id: "nte_001",
-    content:
-      "Spoke with Sarah about the Jenkins pipeline failing on staging. She thinks it's a Docker image caching issue. Need to check the build logs.",
-    title: "Jenkins Pipeline Staging Issue",
-    date: todayStr,
-    sortOrder: 0,
-    userId: "1",
-    dateCreated: "2026-04-18T09:30:00.000Z",
-    dateUpdated: "2026-04-18T09:30:00.000Z",
-  },
-  {
-    id: "nte_002",
-    content:
-      "Meeting with design team — agreed on new colour palette for dashboard. Moving away from blue-heavy scheme to more neutral tones with accent colours per feature area.",
-    title: "Dashboard Redesign Colour Palette",
-    date: todayStr,
-    sortOrder: 1,
-    userId: "1",
-    dateCreated: "2026-04-17T14:15:00.000Z",
-    dateUpdated: "2026-04-17T14:15:00.000Z",
-  },
-  {
-    id: "nte_003",
-    content:
-      "Idea: add keyboard shortcuts for common actions — Cmd+N for new task, Cmd+Shift+N for new note, Cmd+K for search. Check what VS Code and Linear use for reference.",
-    title: null,
-    date: null,
-    sortOrder: 0,
-    userId: "1",
-    dateCreated: "2026-04-16T11:00:00.000Z",
-    dateUpdated: "2026-04-16T11:00:00.000Z",
-  },
-  {
-    id: "nte_004",
-    content:
-      "Performance review prep: shipped task system, calendar integration, and drag-drop. Contributed to design system tokens. Mentored two junior devs on React Query patterns.",
-    title: "Q1 Performance Review Notes",
-    date: null,
-    sortOrder: 1,
-    userId: "1",
-    dateCreated: "2026-04-10T16:45:00.000Z",
-    dateUpdated: "2026-04-15T10:20:00.000Z",
-  },
-];
-
-await db.insert(schema.notes).values(sampleNotes);
-
-// Seed note-tag relationships
-await db.insert(schema.noteTags).values([
-  { noteId: "nte_001", tagId: "tag_002" }, // Jenkins note → backend
-  { noteId: "nte_001", tagId: "tag_003" }, // Jenkins note → urgent
-  { noteId: "nte_002", tagId: "tag_001" }, // Design note → frontend
-  { noteId: "nte_003", tagId: "tag_001" }, // Keyboard shortcuts → frontend
+// Seed task-tag relationships (using itemTags)
+await db.insert(schema.itemTags).values([
+  { itemId: "tsk_001", tagId: "tag_002" },
+  { itemId: "tsk_002", tagId: "tag_002" },
+  { itemId: "tsk_002", tagId: "tag_003" },
+  { itemId: "tsk_003", tagId: "tag_001" },
+  { itemId: "tsk_005", tagId: "tag_001" },
+  { itemId: "tsk_005", tagId: "tag_004" },
+  { itemId: "tsk_006", tagId: "tag_001" },
+  { itemId: "tsk_006", tagId: "tag_003" },
+  { itemId: "tsk_008", tagId: "tag_001" },
+  // Note-tag relationships
+  { itemId: "nte_001", tagId: "tag_002" },
+  { itemId: "nte_001", tagId: "tag_003" },
+  { itemId: "nte_002", tagId: "tag_001" },
+  { itemId: "nte_003", tagId: "tag_001" },
 ]);
 
 // Seed note metadata (AI-generated keywords)
-await db.insert(schema.noteMetadata).values([
+await db.insert(schema.itemMetadata).values([
   {
-    noteId: "nte_001",
+    itemId: "nte_001",
     keywords:
       "Jenkins, CI/CD, pipeline, staging, Docker, caching, build, Sarah, DevOps, infrastructure",
   },
   {
-    noteId: "nte_002",
+    itemId: "nte_002",
     keywords:
       "design, dashboard, colour, palette, UI, redesign, meeting, neutral, accent",
   },
-  { noteId: "nte_003", keywords: null },
+  { itemId: "nte_003", keywords: null },
   {
-    noteId: "nte_004",
+    itemId: "nte_004",
     keywords:
       "performance, review, accomplishments, React Query, mentoring, design system, drag-drop",
   },
 ]);
 
+const taskCount = sampleItems.filter((i) => i.type === "task").length;
+const noteCount = sampleItems.filter((i) => i.type === "note").length;
+
 console.info("Database seeded successfully.");
-console.info(`  - ${sampleTasks.length} tasks (including ${2} subtasks)`);
+console.info(
+  `  - ${taskCount} tasks (including ${subtaskItems.length} subtasks)`,
+);
 console.info(`  - ${4} tags`);
-console.info(`  - ${9} task-tag relationships`);
-console.info(`  - ${sampleNotes.length} notes`);
-console.info(`  - ${4} note-tag relationships`);
+console.info(`  - ${14} item-tag relationships`);
+console.info(`  - ${noteCount} notes`);
 console.info(`  - ${4} note metadata entries`);
 
 await client.end();

--- a/src/features/items/consts.ts
+++ b/src/features/items/consts.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_USER_ID = "1";
+
+export const itemsQueryKeys = {
+  all: ["items"] as const,
+  byId: (id: string) => ["items", id] as const,
+  subtasks: (parentId: string) => ["items", parentId, "subtasks"] as const,
+  byType: (type: string) => ["items", "type", type] as const,
+  byDate: (date: string) => ["items", "byDate", date] as const,
+  byTag: (tagId: string) => ["items", "byTag", tagId] as const,
+};

--- a/src/features/items/server.ts
+++ b/src/features/items/server.ts
@@ -207,7 +207,7 @@ export const updateItem = createServerFn({ method: "POST" })
         .where(and(eq(items.id, id), eq(items.userId, userId)))
         .returning();
 
-      if (tagIds !== undefined) {
+      if (itemResult && tagIds !== undefined) {
         await tx.delete(itemTags).where(eq(itemTags.itemId, id));
 
         if (tagIds.length > 0) {

--- a/src/features/items/server.ts
+++ b/src/features/items/server.ts
@@ -1,0 +1,503 @@
+import { createServerFn } from "@tanstack/react-start";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  isNotNull,
+  isNull,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
+import { generateKeyBetween, generateNKeysBetween } from "fractional-indexing";
+import z from "zod";
+import { db } from "~/db";
+import { items, itemTags, itemMetadata, tags } from "~/db/schema";
+
+const formatLocalDate = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+// ─── Computed columns ────────────────────────────────────────────────
+
+export const itemColumns = {
+  id: items.id,
+  type: items.type,
+  title: items.title,
+  content: items.content,
+  date: items.date,
+  dateCompleted: items.dateCompleted,
+  parentItemId: items.parentItemId,
+  sortOrder: items.sortOrder,
+  userId: items.userId,
+  dateCreated: items.dateCreated,
+  dateUpdated: items.dateUpdated,
+  subtaskCount:
+    sql<number>`(SELECT COUNT(*) FROM items st WHERE st.parent_item_id = "items"."id")`.as(
+      "subtask_count",
+    ),
+  completedSubtaskCount:
+    sql<number>`(SELECT COUNT(*) FROM items st WHERE st.parent_item_id = "items"."id" AND st.date_completed IS NOT NULL)`.as(
+      "completed_subtask_count",
+    ),
+  tags: sql<
+    { id: string; name: string }[]
+  >`(SELECT COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name) ORDER BY t.name), '[]') FROM item_tags it JOIN tags t ON t.id = it.tag_id WHERE it.item_id = "items"."id")`.as(
+    "tags",
+  ),
+};
+
+// ─── Roll forward stale tasks ────────────────────────────────────────
+
+export async function rollForwardStaleTasks(userId: string) {
+  const todayStr = formatLocalDate(new Date());
+
+  const staleTasks = await db
+    .select({ id: items.id, sortOrder: items.sortOrder })
+    .from(items)
+    .where(
+      and(
+        eq(items.userId, userId),
+        eq(items.type, "task"),
+        isNull(items.dateCompleted),
+        isNotNull(items.date),
+        lt(items.date, todayStr),
+      ),
+    )
+    .orderBy(asc(items.sortOrder));
+
+  if (staleTasks.length === 0) return;
+
+  const [maxRow] = await db
+    .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+    .from(items)
+    .where(
+      and(
+        eq(items.userId, userId),
+        eq(items.type, "task"),
+        isNull(items.dateCompleted),
+        isNull(items.parentItemId),
+        eq(items.date, todayStr),
+      ),
+    );
+
+  const lastKey = maxRow?.max ?? null;
+  const newKeys = generateNKeysBetween(lastKey, null, staleTasks.length);
+
+  const valuesList = sql.join(
+    staleTasks.map((t, i) => sql`(${t.id}, ${todayStr}, ${newKeys[i]})`),
+    sql`, `,
+  );
+
+  await db.execute(
+    sql`UPDATE items SET date = v.date, sort_order = v.sort_order
+        FROM (VALUES ${valuesList}) AS v(id, date, sort_order)
+        WHERE items.id = v.id AND items.user_id = ${userId}`,
+  );
+}
+
+// ─── Generic CRUD ────────────────────────────────────────────────────
+
+export const createItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      type: z.enum(["task", "note", "event"]),
+      title: z.string().min(1).max(255),
+      content: z.string().max(10000).optional(),
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .optional(),
+      parentItemId: z.string().optional(),
+      tagIds: z.array(z.string()).optional(),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const prefix =
+      data.type === "task" ? "tsk_" : data.type === "note" ? "nte_" : "evt_";
+    const id = `${prefix}${crypto.randomUUID()}`;
+    const now = new Date().toISOString();
+
+    const result = await db.transaction(async (tx) => {
+      // Get the max sortOrder for items in the same context
+      const dateCondition = data.date
+        ? eq(items.date, data.date)
+        : isNull(items.date);
+
+      const parentCondition = data.parentItemId
+        ? eq(items.parentItemId, data.parentItemId)
+        : isNull(items.parentItemId);
+
+      const [maxRow] = await tx
+        .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+        .from(items)
+        .where(
+          and(
+            eq(items.userId, data.userId),
+            eq(items.type, data.type),
+            isNull(items.dateCompleted),
+            parentCondition,
+            dateCondition,
+          ),
+        );
+
+      const nextSortOrder = generateKeyBetween(maxRow?.max ?? null, null);
+
+      const [itemResult] = await tx
+        .insert(items)
+        .values({
+          id,
+          type: data.type,
+          title: data.title,
+          content: data.content ?? null,
+          date: data.date ?? null,
+          dateCompleted: null,
+          parentItemId: data.parentItemId ?? null,
+          sortOrder: nextSortOrder,
+          userId: data.userId,
+          dateCreated: now,
+          dateUpdated: now,
+        })
+        .returning();
+
+      if (data.tagIds && data.tagIds.length > 0) {
+        await tx
+          .insert(itemTags)
+          .values(data.tagIds.map((tagId) => ({ itemId: id, tagId })));
+      }
+
+      // Create metadata row for notes (AI will fill later)
+      if (data.type === "note") {
+        await tx.insert(itemMetadata).values({ itemId: id });
+      }
+
+      return itemResult;
+    });
+
+    return result;
+  });
+
+export const updateItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      id: z.string().min(1),
+      title: z.string().min(1).max(255).optional(),
+      content: z.string().max(10000).or(z.null()).optional(),
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .or(z.null())
+        .optional(),
+      dateCompleted: z.string().or(z.null()).optional(),
+      tagIds: z.array(z.string()).optional(),
+      sortOrder: z.string().optional(),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    console.info(`Updating item ${data.id}...`);
+
+    const { id, userId, tagIds, ...updates } = data;
+
+    const result = await db.transaction(async (tx) => {
+      const [itemResult] = await tx
+        .update(items)
+        .set({ ...updates, dateUpdated: new Date().toISOString() })
+        .where(and(eq(items.id, id), eq(items.userId, userId)))
+        .returning();
+
+      if (tagIds !== undefined) {
+        await tx.delete(itemTags).where(eq(itemTags.itemId, id));
+
+        if (tagIds.length > 0) {
+          await tx
+            .insert(itemTags)
+            .values(tagIds.map((tagId) => ({ itemId: id, tagId })));
+        }
+      }
+
+      return itemResult;
+    });
+
+    return result;
+  });
+
+export const deleteItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      itemId: z.string().min(1),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    console.info(`Deleting item ${data.itemId}...`);
+
+    await db.transaction(async (tx) => {
+      // Delete subtasks first
+      await tx
+        .delete(items)
+        .where(
+          and(
+            eq(items.parentItemId, data.itemId),
+            eq(items.userId, data.userId),
+          ),
+        );
+
+      await tx
+        .delete(items)
+        .where(and(eq(items.id, data.itemId), eq(items.userId, data.userId)));
+    });
+  });
+
+export const completeItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      itemId: z.string().min(1),
+      dateCompleted: z.string().or(z.null()),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    console.info(`Completing item ${data.itemId}...`);
+
+    const [result] = await db
+      .update(items)
+      .set({
+        dateCompleted: data.dateCompleted,
+        dateUpdated: new Date().toISOString(),
+      })
+      .where(and(eq(items.id, data.itemId), eq(items.userId, data.userId)))
+      .returning();
+
+    return result;
+  });
+
+export const reorderItems = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      itemIds: z.array(z.string().min(1)).min(1),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    console.info(`Reordering ${data.itemIds.length} items...`);
+
+    const newKeys = generateNKeysBetween(null, null, data.itemIds.length);
+
+    const valuesList = sql.join(
+      data.itemIds.map((id, i) => sql`(${id}, ${newKeys[i]})`),
+      sql`, `,
+    );
+
+    await db.execute(
+      sql`UPDATE items SET sort_order = v.sort_order
+          FROM (VALUES ${valuesList}) AS v(id, sort_order)
+          WHERE items.id = v.id AND items.user_id = ${data.userId}`,
+    );
+  });
+
+export const moveItemToDate = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      itemId: z.string().min(1),
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .or(z.null()),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    console.info(`Moving item ${data.itemId} to date ${data.date}...`);
+
+    const dateCondition = data.date
+      ? eq(items.date, data.date)
+      : isNull(items.date);
+
+    const [maxRow] = await db
+      .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+      .from(items)
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          isNull(items.parentItemId),
+          isNull(items.dateCompleted),
+          dateCondition,
+        ),
+      );
+
+    const newKey = generateKeyBetween(maxRow?.max ?? null, null);
+
+    const [result] = await db
+      .update(items)
+      .set({
+        date: data.date,
+        sortOrder: newKey,
+        dateUpdated: new Date().toISOString(),
+      })
+      .where(and(eq(items.id, data.itemId), eq(items.userId, data.userId)))
+      .returning();
+
+    return result;
+  });
+
+export const fetchItemWithRelations = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      itemId: z.string().min(1),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const result = await db.query.items.findFirst({
+      where: and(eq(items.id, data.itemId), eq(items.userId, data.userId)),
+      with: {
+        itemTags: {
+          with: {
+            tag: true,
+          },
+        },
+        subtasks: true,
+        metadata: true,
+      },
+    });
+
+    if (!result) return null;
+
+    const completedSubtasks = result.subtasks.filter(
+      (s) => s.dateCompleted !== null,
+    );
+
+    return {
+      ...result,
+      tags: result.itemTags.map((it) => it.tag),
+      subtasks: result.subtasks.map((s) => ({
+        ...s,
+        subtaskCount: 0,
+        completedSubtaskCount: 0,
+        tags: [] as { id: string; name: string }[],
+      })),
+      subtaskCount: result.subtasks.length,
+      completedSubtaskCount: completedSubtasks.length,
+      metadata: result.metadata,
+    };
+  });
+
+export const fetchSubtasks = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      parentItemId: z.string().min(1),
+      userId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }) => {
+    return db
+      .select({
+        id: items.id,
+        type: items.type,
+        title: items.title,
+        content: items.content,
+        date: items.date,
+        dateCompleted: items.dateCompleted,
+        parentItemId: items.parentItemId,
+        sortOrder: items.sortOrder,
+        userId: items.userId,
+        dateCreated: items.dateCreated,
+        dateUpdated: items.dateUpdated,
+        subtaskCount: sql<number>`0`.as("subtask_count"),
+        completedSubtaskCount: sql<number>`0`.as("completed_subtask_count"),
+        tags: sql<{ id: string; name: string }[]>`'[]'::json`.as("tags"),
+      })
+      .from(items)
+      .where(
+        and(
+          eq(items.parentItemId, data.parentItemId),
+          eq(items.userId, data.userId),
+        ),
+      )
+      .orderBy(asc(items.dateCompleted), asc(items.dateCreated));
+  });
+
+// ─── Type-filtered queries ───────────────────────────────────────────
+
+export const fetchItemsForDate = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      userId: z.string().min(1),
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      type: z.enum(["task", "note", "event"]).optional(),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const todayStr = formatLocalDate(new Date());
+    if (data.date === todayStr) {
+      await rollForwardStaleTasks(data.userId);
+    }
+
+    const typeFilter = data.type ? eq(items.type, data.type) : undefined;
+
+    return db
+      .select(itemColumns)
+      .from(items)
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          isNull(items.parentItemId),
+          typeFilter,
+          or(
+            // Incomplete items: only on their exact date
+            and(isNull(items.dateCompleted), eq(items.date, data.date)),
+            // Completed tasks: only on the day they were completed
+            and(
+              isNotNull(items.dateCompleted),
+              eq(items.type, "task"),
+              eq(sql`CAST(${items.dateCompleted} AS date)`, data.date),
+            ),
+          ),
+        ),
+      )
+      .orderBy(
+        desc(isNull(items.dateCompleted)),
+        sql`CASE WHEN ${items.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
+        asc(items.sortOrder),
+        asc(items.dateCompleted),
+      );
+  });
+
+export const fetchItemsByTag = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      userId: z.string().min(1),
+      tagId: z.string().min(1),
+      type: z.enum(["task", "note", "event"]).optional(),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const [tag] = await db
+      .select({ name: tags.name, description: tags.description })
+      .from(tags)
+      .where(and(eq(tags.id, data.tagId), eq(tags.userId, data.userId)));
+
+    const typeFilter = data.type ? eq(items.type, data.type) : undefined;
+
+    const itemList = await db
+      .select(itemColumns)
+      .from(items)
+      .innerJoin(itemTags, eq(itemTags.itemId, items.id))
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          eq(itemTags.tagId, data.tagId),
+          isNull(items.parentItemId),
+          typeFilter,
+        ),
+      )
+      .orderBy(
+        sql`CASE WHEN ${items.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
+        asc(items.sortOrder),
+        asc(items.dateCompleted),
+      );
+
+    return { tag: tag ?? null, items: itemList };
+  });

--- a/src/features/items/types.ts
+++ b/src/features/items/types.ts
@@ -1,0 +1,28 @@
+import { Tag } from "~/features/tags/types";
+
+export type ItemType = "task" | "note" | "event";
+
+export type Item = {
+  id: string;
+  type: ItemType;
+  title: string;
+  content: string | null;
+  date: string | null;
+  dateCompleted: string | null;
+  parentItemId: string | null;
+  sortOrder: string;
+  userId: string;
+  dateCreated: string;
+  dateUpdated: string;
+  subtaskCount: number;
+  completedSubtaskCount: number;
+  tags: { id: string; name: string }[];
+};
+
+export type ItemWithRelations = Item & {
+  tags: Tag[];
+  subtasks: Item[];
+  metadata: {
+    keywords: string | null;
+  } | null;
+};

--- a/src/features/notes/ai.ts
+++ b/src/features/notes/ai.ts
@@ -2,7 +2,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { and, eq } from "drizzle-orm";
 import z from "zod";
 import { db } from "~/db";
-import { noteMetadata, notes } from "~/db/schema";
+import { items, itemMetadata } from "~/db/schema";
 import { getAIProvider } from "~/features/ai/provider";
 
 export const processNoteWithAI = createServerFn({ method: "POST" })
@@ -16,8 +16,12 @@ export const processNoteWithAI = createServerFn({ method: "POST" })
       return { updated: false };
     }
 
-    const note = await db.query.notes.findFirst({
-      where: and(eq(notes.id, data.noteId), eq(notes.userId, data.userId)),
+    const note = await db.query.items.findFirst({
+      where: and(
+        eq(items.id, data.noteId),
+        eq(items.userId, data.userId),
+        eq(items.type, "note"),
+      ),
     });
 
     if (!note) return { updated: false };
@@ -25,13 +29,13 @@ export const processNoteWithAI = createServerFn({ method: "POST" })
     try {
       // Only generate title if none was provided by the user
       let title: string | undefined;
-      if (!note.title) {
-        title = await provider.generateTitle(note.content);
+      if (!note.title || note.title === "Untitled") {
+        title = await provider.generateTitle(note.content ?? "");
         console.info(`AI generated title for ${data.noteId}: "${title}"`);
       }
 
       // Always generate keywords
-      const keywords = await provider.generateKeywords(note.content);
+      const keywords = await provider.generateKeywords(note.content ?? "");
       const keywordsStr = keywords.join(", ");
       console.info(
         `AI generated ${keywords.length} keywords for ${data.noteId}`,
@@ -40,15 +44,15 @@ export const processNoteWithAI = createServerFn({ method: "POST" })
       // Update note title (if generated) and metadata keywords
       if (title) {
         await db
-          .update(notes)
+          .update(items)
           .set({ title, dateUpdated: new Date().toISOString() })
-          .where(and(eq(notes.id, data.noteId), eq(notes.userId, data.userId)));
+          .where(and(eq(items.id, data.noteId), eq(items.userId, data.userId)));
       }
 
       await db
-        .update(noteMetadata)
+        .update(itemMetadata)
         .set({ keywords: keywordsStr })
-        .where(eq(noteMetadata.noteId, data.noteId));
+        .where(eq(itemMetadata.itemId, data.noteId));
 
       return { updated: true, title };
     } catch (err) {

--- a/src/features/notes/ai.ts
+++ b/src/features/notes/ai.ts
@@ -46,7 +46,13 @@ export const processNoteWithAI = createServerFn({ method: "POST" })
         await db
           .update(items)
           .set({ title, dateUpdated: new Date().toISOString() })
-          .where(and(eq(items.id, data.noteId), eq(items.userId, data.userId)));
+          .where(
+            and(
+              eq(items.id, data.noteId),
+              eq(items.userId, data.userId),
+              eq(items.type, "note"),
+            ),
+          );
       }
 
       await db

--- a/src/features/notes/mutations.test.ts
+++ b/src/features/notes/mutations.test.ts
@@ -30,7 +30,7 @@ function makeFakeNote(overrides: Partial<Note> = {}): Note {
     content: "Some note content",
     title: "Test Note",
     date: "2026-04-19",
-    sortOrder: 0,
+    sortOrder: "a0",
     userId: "1",
     dateCreated: "2026-01-01T00:00:00Z",
     dateUpdated: "2026-01-01T00:00:00Z",

--- a/src/features/notes/mutations.ts
+++ b/src/features/notes/mutations.ts
@@ -31,7 +31,7 @@ export const useUpdateNote = () => {
       title?: string | null;
       date?: string | null;
       tagIds?: string[];
-      sortOrder?: number;
+      sortOrder?: string;
     }) => updateNote({ data: { ...input, userId: DEFAULT_USER_ID } }),
     onSettled: (_data, _err, input) => {
       queryClient.invalidateQueries({ queryKey: notesQueryKeys.all });

--- a/src/features/notes/server.ts
+++ b/src/features/notes/server.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
-import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
+import { generateKeyBetween, generateNKeysBetween } from "fractional-indexing";
 import z from "zod";
 import { db } from "~/db";
 import { items, itemTags, itemMetadata } from "~/db/schema";
@@ -9,7 +10,7 @@ const noteColumns = {
   content: sql<string>`COALESCE(${items.content}, '')`.as("content"),
   title: items.title,
   date: items.date,
-  sortOrder: sql<number>`CAST(${items.sortOrder} AS integer)`.as("sort_order"),
+  sortOrder: items.sortOrder,
   userId: items.userId,
   dateCreated: items.dateCreated,
   dateUpdated: items.dateUpdated,
@@ -74,7 +75,7 @@ export const fetchNotesForDate = createServerFn({ method: "GET" })
           eq(items.date, data.date),
         ),
       )
-      .orderBy(asc(sql`CAST(${items.sortOrder} AS integer)`));
+      .orderBy(asc(items.sortOrder));
   });
 
 export const fetchNotesByTag = createServerFn({ method: "GET" })
@@ -162,11 +163,11 @@ export const createNote = createServerFn({ method: "POST" })
           and(
             eq(items.userId, data.userId),
             eq(items.type, "note"),
-            data.date ? eq(items.date, data.date) : sql`${items.date} IS NULL`,
+            data.date ? eq(items.date, data.date) : isNull(items.date),
           ),
         );
 
-      const nextSortOrder = String((Number(maxRow?.max ?? "-1") || 0) + 1);
+      const nextSortOrder = generateKeyBetween(maxRow?.max ?? null, null);
 
       const [noteResult] = await tx
         .insert(items)
@@ -214,23 +215,19 @@ export const updateNote = createServerFn({ method: "POST" })
         .or(z.null())
         .optional(),
       tagIds: z.array(z.string()).optional(),
-      sortOrder: z.number().optional(),
+      sortOrder: z.string().optional(),
       userId: z.string().min(1),
     }),
   )
   .handler(async ({ data }) => {
     console.info(`Updating note ${data.id}...`);
 
-    const { id, userId, tagIds, sortOrder, ...updates } = data;
+    const { id, userId, tagIds, ...updates } = data;
 
-    // Convert integer sortOrder to text for items table
     const setValues: Record<string, unknown> = {
       ...updates,
       dateUpdated: new Date().toISOString(),
     };
-    if (sortOrder !== undefined) {
-      setValues.sortOrder = String(sortOrder);
-    }
 
     const result = await db.transaction(async (tx) => {
       const [noteResult] = await tx
@@ -296,8 +293,10 @@ export const reorderNotes = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Reordering ${data.noteIds.length} notes...`);
 
+    const newKeys = generateNKeysBetween(null, null, data.noteIds.length);
+
     const valuesList = sql.join(
-      data.noteIds.map((id, i) => sql`(${id}, ${String(i)})`),
+      data.noteIds.map((id, i) => sql`(${id}, ${newKeys[i]})`),
       sql`, `,
     );
 

--- a/src/features/notes/server.ts
+++ b/src/features/notes/server.ts
@@ -2,20 +2,20 @@ import { createServerFn } from "@tanstack/react-start";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import z from "zod";
 import { db } from "~/db";
-import { noteMetadata, notes, noteTags } from "~/db/schema";
+import { items, itemTags, itemMetadata } from "~/db/schema";
 
 const noteColumns = {
-  id: notes.id,
-  content: notes.content,
-  title: notes.title,
-  date: notes.date,
-  sortOrder: notes.sortOrder,
-  userId: notes.userId,
-  dateCreated: notes.dateCreated,
-  dateUpdated: notes.dateUpdated,
+  id: items.id,
+  content: sql<string>`COALESCE(${items.content}, '')`.as("content"),
+  title: items.title,
+  date: items.date,
+  sortOrder: sql<number>`CAST(${items.sortOrder} AS integer)`.as("sort_order"),
+  userId: items.userId,
+  dateCreated: items.dateCreated,
+  dateUpdated: items.dateUpdated,
   tags: sql<
     { id: string; name: string }[]
-  >`(SELECT COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name) ORDER BY t.name), '[]') FROM note_tags nt JOIN tags t ON t.id = nt.tag_id WHERE nt.note_id = "notes"."id")`.as(
+  >`(SELECT COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name) ORDER BY t.name), '[]') FROM item_tags it JOIN tags t ON t.id = it.tag_id WHERE it.item_id = "items"."id")`.as(
     "tags",
   ),
 };
@@ -35,16 +35,16 @@ export const fetchNotes = createServerFn({ method: "GET" })
 
     const [countResult] = await db
       .select({ count: sql<number>`COUNT(*)` })
-      .from(notes)
-      .where(eq(notes.userId, data.userId));
+      .from(items)
+      .where(and(eq(items.userId, data.userId), eq(items.type, "note")));
 
     const total = Number(countResult?.count ?? 0);
 
     const noteList = await db
       .select(noteColumns)
-      .from(notes)
-      .where(eq(notes.userId, data.userId))
-      .orderBy(desc(notes.dateUpdated))
+      .from(items)
+      .where(and(eq(items.userId, data.userId), eq(items.type, "note")))
+      .orderBy(desc(items.dateUpdated))
       .limit(data.limit)
       .offset(offset);
 
@@ -66,9 +66,15 @@ export const fetchNotesForDate = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     return db
       .select(noteColumns)
-      .from(notes)
-      .where(and(eq(notes.userId, data.userId), eq(notes.date, data.date)))
-      .orderBy(asc(notes.sortOrder));
+      .from(items)
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          eq(items.type, "note"),
+          eq(items.date, data.date),
+        ),
+      )
+      .orderBy(asc(items.sortOrder));
   });
 
 export const fetchNotesByTag = createServerFn({ method: "GET" })
@@ -81,10 +87,16 @@ export const fetchNotesByTag = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     return db
       .select(noteColumns)
-      .from(notes)
-      .innerJoin(noteTags, eq(noteTags.noteId, notes.id))
-      .where(and(eq(notes.userId, data.userId), eq(noteTags.tagId, data.tagId)))
-      .orderBy(desc(notes.dateUpdated));
+      .from(items)
+      .innerJoin(itemTags, eq(itemTags.itemId, items.id))
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          eq(items.type, "note"),
+          eq(itemTags.tagId, data.tagId),
+        ),
+      )
+      .orderBy(desc(items.dateUpdated));
   });
 
 export const fetchNote = createServerFn({ method: "GET" })
@@ -95,10 +107,14 @@ export const fetchNote = createServerFn({ method: "GET" })
     }),
   )
   .handler(async ({ data }) => {
-    const result = await db.query.notes.findFirst({
-      where: and(eq(notes.id, data.noteId), eq(notes.userId, data.userId)),
+    const result = await db.query.items.findFirst({
+      where: and(
+        eq(items.id, data.noteId),
+        eq(items.userId, data.userId),
+        eq(items.type, "note"),
+      ),
       with: {
-        noteTags: {
+        itemTags: {
           with: {
             tag: true,
           },
@@ -111,7 +127,8 @@ export const fetchNote = createServerFn({ method: "GET" })
 
     return {
       ...result,
-      tags: result.noteTags.map((nt) => nt.tag),
+      content: result.content ?? "",
+      tags: result.itemTags.map((it) => it.tag),
       metadata: result.metadata,
     };
   });
@@ -138,26 +155,29 @@ export const createNote = createServerFn({ method: "POST" })
     const now = new Date().toISOString();
 
     const result = await db.transaction(async (tx) => {
-      // Get max sortOrder for notes on this date
       const [maxRow] = await tx
-        .select({ max: sql<number>`COALESCE(MAX(${notes.sortOrder}), -1)` })
-        .from(notes)
+        .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+        .from(items)
         .where(
           and(
-            eq(notes.userId, data.userId),
-            data.date ? eq(notes.date, data.date) : sql`${notes.date} IS NULL`,
+            eq(items.userId, data.userId),
+            eq(items.type, "note"),
+            data.date ? eq(items.date, data.date) : sql`${items.date} IS NULL`,
           ),
         );
 
-      const nextSortOrder = (maxRow?.max ?? -1) + 1;
+      const nextSortOrder = String((Number(maxRow?.max ?? "-1") || 0) + 1);
 
       const [noteResult] = await tx
-        .insert(notes)
+        .insert(items)
         .values({
           id,
+          type: "note",
+          title: data.title ?? "Untitled",
           content: data.content,
-          title: data.title ?? null,
           date: data.date ?? null,
+          dateCompleted: null,
+          parentItemId: null,
           sortOrder: nextSortOrder,
           userId: data.userId,
           dateCreated: now,
@@ -167,12 +187,12 @@ export const createNote = createServerFn({ method: "POST" })
 
       if (data.tagIds && data.tagIds.length > 0) {
         await tx
-          .insert(noteTags)
-          .values(data.tagIds.map((tagId) => ({ noteId: id, tagId })));
+          .insert(itemTags)
+          .values(data.tagIds.map((tagId) => ({ itemId: id, tagId })));
       }
 
-      // Create empty noteMetadata row for AI to fill later
-      await tx.insert(noteMetadata).values({ noteId: id });
+      // Create empty metadata row for AI to fill later
+      await tx.insert(itemMetadata).values({ itemId: id });
 
       return noteResult;
     });
@@ -201,22 +221,31 @@ export const updateNote = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Updating note ${data.id}...`);
 
-    const { id, userId, tagIds, ...updates } = data;
+    const { id, userId, tagIds, sortOrder, ...updates } = data;
+
+    // Convert integer sortOrder to text for items table
+    const setValues: Record<string, unknown> = {
+      ...updates,
+      dateUpdated: new Date().toISOString(),
+    };
+    if (sortOrder !== undefined) {
+      setValues.sortOrder = String(sortOrder);
+    }
 
     const result = await db.transaction(async (tx) => {
       const [noteResult] = await tx
-        .update(notes)
-        .set({ ...updates, dateUpdated: new Date().toISOString() })
-        .where(and(eq(notes.id, id), eq(notes.userId, userId)))
+        .update(items)
+        .set(setValues)
+        .where(and(eq(items.id, id), eq(items.userId, userId)))
         .returning();
 
       if (tagIds !== undefined) {
-        await tx.delete(noteTags).where(eq(noteTags.noteId, id));
+        await tx.delete(itemTags).where(eq(itemTags.itemId, id));
 
         if (tagIds.length > 0) {
           await tx
-            .insert(noteTags)
-            .values(tagIds.map((tagId) => ({ noteId: id, tagId })));
+            .insert(itemTags)
+            .values(tagIds.map((tagId) => ({ itemId: id, tagId })));
         }
       }
 
@@ -239,8 +268,8 @@ export const deleteNote = createServerFn({ method: "POST" })
     console.info(`Deleting note ${data.noteId}...`);
 
     await db
-      .delete(notes)
-      .where(and(eq(notes.id, data.noteId), eq(notes.userId, data.userId)));
+      .delete(items)
+      .where(and(eq(items.id, data.noteId), eq(items.userId, data.userId)));
   });
 
 // ─── Reorder ─────────────────────────────────────────────────────────
@@ -256,14 +285,14 @@ export const reorderNotes = createServerFn({ method: "POST" })
     console.info(`Reordering ${data.noteIds.length} notes...`);
 
     const valuesList = sql.join(
-      data.noteIds.map((id, i) => sql`(${id}, ${i})`),
+      data.noteIds.map((id, i) => sql`(${id}, ${String(i)})`),
       sql`, `,
     );
 
     await db.execute(
-      sql`UPDATE notes SET sort_order = v.sort_order
+      sql`UPDATE items SET sort_order = v.sort_order
           FROM (VALUES ${valuesList}) AS v(id, sort_order)
-          WHERE notes.id = v.id AND notes.user_id = ${data.userId}`,
+          WHERE items.id = v.id AND items.user_id = ${data.userId}`,
     );
   });
 
@@ -281,28 +310,27 @@ export const searchNotes = createServerFn({ method: "GET" })
     const tsQuery = sql`plainto_tsquery('english', ${data.query})`;
     const likePattern = `%${data.query}%`;
 
-    // Build search with ts_rank across content, title, and keywords
-    // Fall back to ILIKE for partial/short queries that tsvector misses
     let query = db
       .select({
         ...noteColumns,
         rank: sql<number>`GREATEST(
           ts_rank(
-            to_tsvector('english', COALESCE("notes"."content", '') || ' ' || COALESCE("notes"."title", '') || ' ' || COALESCE("note_metadata"."keywords", '')),
+            to_tsvector('english', COALESCE("items"."content", '') || ' ' || COALESCE("items"."title", '') || ' ' || COALESCE("item_metadata"."keywords", '')),
             ${tsQuery}
           ),
-          CASE WHEN "notes"."content" ILIKE ${likePattern} OR "notes"."title" ILIKE ${likePattern} THEN 0.1 ELSE 0 END
+          CASE WHEN "items"."content" ILIKE ${likePattern} OR "items"."title" ILIKE ${likePattern} THEN 0.1 ELSE 0 END
         )`.as("rank"),
       })
-      .from(notes)
-      .leftJoin(noteMetadata, eq(noteMetadata.noteId, notes.id))
+      .from(items)
+      .leftJoin(itemMetadata, eq(itemMetadata.itemId, items.id))
       .where(
         and(
-          eq(notes.userId, data.userId),
+          eq(items.userId, data.userId),
+          eq(items.type, "note"),
           sql`(
-            to_tsvector('english', COALESCE("notes"."content", '') || ' ' || COALESCE("notes"."title", '') || ' ' || COALESCE("note_metadata"."keywords", '')) @@ ${tsQuery}
-            OR "notes"."content" ILIKE ${likePattern}
-            OR "notes"."title" ILIKE ${likePattern}
+            to_tsvector('english', COALESCE("items"."content", '') || ' ' || COALESCE("items"."title", '') || ' ' || COALESCE("item_metadata"."keywords", '')) @@ ${tsQuery}
+            OR "items"."content" ILIKE ${likePattern}
+            OR "items"."title" ILIKE ${likePattern}
           )`,
         ),
       )
@@ -311,7 +339,7 @@ export const searchNotes = createServerFn({ method: "GET" })
     if (data.tagIds && data.tagIds.length > 0) {
       for (const tagId of data.tagIds) {
         query = query.where(
-          sql`EXISTS (SELECT 1 FROM note_tags WHERE note_tags.note_id = "notes"."id" AND note_tags.tag_id = ${tagId})`,
+          sql`EXISTS (SELECT 1 FROM item_tags WHERE item_tags.item_id = "items"."id" AND item_tags.tag_id = ${tagId})`,
         );
       }
     }

--- a/src/features/notes/server.ts
+++ b/src/features/notes/server.ts
@@ -74,7 +74,7 @@ export const fetchNotesForDate = createServerFn({ method: "GET" })
           eq(items.date, data.date),
         ),
       )
-      .orderBy(asc(items.sortOrder));
+      .orderBy(asc(sql`CAST(${items.sortOrder} AS integer)`));
   });
 
 export const fetchNotesByTag = createServerFn({ method: "GET" })
@@ -236,10 +236,16 @@ export const updateNote = createServerFn({ method: "POST" })
       const [noteResult] = await tx
         .update(items)
         .set(setValues)
-        .where(and(eq(items.id, id), eq(items.userId, userId)))
+        .where(
+          and(
+            eq(items.id, id),
+            eq(items.userId, userId),
+            eq(items.type, "note"),
+          ),
+        )
         .returning();
 
-      if (tagIds !== undefined) {
+      if (noteResult && tagIds !== undefined) {
         await tx.delete(itemTags).where(eq(itemTags.itemId, id));
 
         if (tagIds.length > 0) {
@@ -269,7 +275,13 @@ export const deleteNote = createServerFn({ method: "POST" })
 
     await db
       .delete(items)
-      .where(and(eq(items.id, data.noteId), eq(items.userId, data.userId)));
+      .where(
+        and(
+          eq(items.id, data.noteId),
+          eq(items.userId, data.userId),
+          eq(items.type, "note"),
+        ),
+      );
   });
 
 // ─── Reorder ─────────────────────────────────────────────────────────
@@ -292,7 +304,7 @@ export const reorderNotes = createServerFn({ method: "POST" })
     await db.execute(
       sql`UPDATE items SET sort_order = v.sort_order
           FROM (VALUES ${valuesList}) AS v(id, sort_order)
-          WHERE items.id = v.id AND items.user_id = ${data.userId}`,
+          WHERE items.id = v.id AND items.user_id = ${data.userId} AND items.type = 'note'`,
     );
   });
 

--- a/src/features/notes/types.ts
+++ b/src/features/notes/types.ts
@@ -5,7 +5,7 @@ export type Note = {
   content: string;
   title: string | null;
   date: string | null;
-  sortOrder: number;
+  sortOrder: string;
   userId: string;
   dateCreated: string;
   dateUpdated: string;
@@ -32,7 +32,7 @@ export type UpdateNoteInput = {
   title?: string | null;
   date?: string | null;
   tagIds?: string[];
-  sortOrder?: number;
+  sortOrder?: string;
 };
 
 export type PaginatedNotes = {

--- a/src/features/tasks/server.ts
+++ b/src/features/tasks/server.ts
@@ -6,7 +6,6 @@ import {
   eq,
   isNotNull,
   isNull,
-  lt,
   lte,
   or,
   sql,
@@ -14,101 +13,46 @@ import {
 import { generateKeyBetween, generateNKeysBetween } from "fractional-indexing";
 import z from "zod";
 import { db } from "~/db";
-import { tags, tasks, taskTags } from "~/db/schema";
+import { items, itemTags, tags } from "~/db/schema";
+import { itemColumns, rollForwardStaleTasks } from "~/features/items/server";
+import type { Task } from "./types";
 
 const userIdInput = z.object({ userId: z.string().min(1) });
 
 const formatLocalDate = (d: Date) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 
-/**
- * Roll forward any incomplete tasks whose startDate is in the past to today.
- * Re-keys their sortOrder so they appear after today's existing tasks.
- * Runs lazily before task fetches — no background process needed.
- */
-async function rollForwardStaleTasks(userId: string) {
-  const todayStr = formatLocalDate(new Date());
+// ─── Item → Task mapping ─────────────────────────────────────────────
 
-  // Find stale tasks (past startDate, incomplete)
-  const staleTasks = await db
-    .select({ id: tasks.id, sortOrder: tasks.sortOrder })
-    .from(tasks)
-    .where(
-      and(
-        eq(tasks.userId, userId),
-        isNull(tasks.dateCompleted),
-        isNotNull(tasks.startDate),
-        lt(tasks.startDate, todayStr),
-      ),
-    )
-    .orderBy(asc(tasks.sortOrder));
-
-  if (staleTasks.length === 0) return;
-
-  // Find the max sortOrder among today's existing incomplete tasks
-  const [maxRow] = await db
-    .select({ max: sql<string | null>`MAX(${tasks.sortOrder})` })
-    .from(tasks)
-    .where(
-      and(
-        eq(tasks.userId, userId),
-        isNull(tasks.dateCompleted),
-        isNull(tasks.parentTaskId),
-        eq(tasks.startDate, todayStr),
-      ),
-    );
-
-  const lastKey = maxRow?.max ?? null;
-
-  // Generate keys for the stale tasks that sort after today's last task
-  const newKeys = generateNKeysBetween(lastKey, null, staleTasks.length);
-
-  // Batch update: move to today and assign new sort keys
-  const valuesList = sql.join(
-    staleTasks.map((t, i) => sql`(${t.id}, ${todayStr}, ${newKeys[i]})`),
-    sql`, `,
-  );
-
-  await db.execute(
-    sql`UPDATE tasks SET start_date = v.start_date, sort_order = v.sort_order
-        FROM (VALUES ${valuesList}) AS v(id, start_date, sort_order)
-        WHERE tasks.id = v.id AND tasks.user_id = ${userId}`,
-  );
+function toTask(row: Record<string, unknown>): Task {
+  const r = row as Record<string, unknown>;
+  return {
+    id: r.id as string,
+    title: r.title as string,
+    notes: (r.content as string | null) ?? null,
+    dateCreated: r.dateCreated as string,
+    dateCompleted: (r.dateCompleted as string | null) ?? null,
+    startDate: (r.date as string | null) ?? null,
+    userId: r.userId as string,
+    parentTaskId: (r.parentItemId as string | null) ?? null,
+    sortOrder: r.sortOrder as string,
+    subtaskCount: r.subtaskCount as number,
+    completedSubtaskCount: r.completedSubtaskCount as number,
+    tags: r.tags as { id: string; name: string }[],
+  };
 }
 
-const taskColumns = {
-  id: tasks.id,
-  title: tasks.title,
-  notes: tasks.notes,
-  dateCreated: tasks.dateCreated,
-  dateCompleted: tasks.dateCompleted,
-  startDate: tasks.startDate,
-  userId: tasks.userId,
-  parentTaskId: tasks.parentTaskId,
-  sortOrder: tasks.sortOrder,
-  subtaskCount:
-    sql<number>`(SELECT COUNT(*) FROM tasks st WHERE st.parent_task_id = "tasks"."id")`.as(
-      "subtask_count",
-    ),
-  completedSubtaskCount:
-    sql<number>`(SELECT COUNT(*) FROM tasks st WHERE st.parent_task_id = "tasks"."id" AND st.date_completed IS NOT NULL)`.as(
-      "completed_subtask_count",
-    ),
-  tags: sql<
-    { id: string; name: string }[]
-  >`(SELECT COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name) ORDER BY t.name), '[]') FROM task_tags tt JOIN tags t ON t.id = tt.tag_id WHERE tt.task_id = "tasks"."id")`.as(
-    "tags",
-  ),
-};
+// ─── List & Fetch ────────────────────────────────────────────────────
 
 export const fetchTasks = createServerFn({ method: "GET" })
   .inputValidator(userIdInput)
   .handler(async ({ data }) => {
-    return db
-      .select(taskColumns)
-      .from(tasks)
-      .where(eq(tasks.userId, data.userId))
-      .orderBy(asc(tasks.sortOrder));
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
+      .where(and(eq(items.userId, data.userId), eq(items.type, "task")))
+      .orderBy(asc(items.sortOrder));
+    return rows.map(toTask);
   });
 
 export const fetchInboxTasks = createServerFn({ method: "GET" })
@@ -118,32 +62,41 @@ export const fetchInboxTasks = createServerFn({ method: "GET" })
 
     const todayStr = formatLocalDate(new Date());
 
-    return db
-      .select(taskColumns)
-      .from(tasks)
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
       .where(
         and(
-          eq(tasks.userId, data.userId),
-          isNull(tasks.parentTaskId),
-          or(isNull(tasks.startDate), lte(tasks.startDate, todayStr)),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          isNull(items.parentItemId),
+          or(isNull(items.date), lte(items.date, todayStr)),
         ),
       )
       .orderBy(
-        desc(isNull(tasks.dateCompleted)),
-        sql`CASE WHEN ${tasks.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
-        asc(tasks.sortOrder),
-        asc(tasks.dateCompleted),
+        desc(isNull(items.dateCompleted)),
+        sql`CASE WHEN ${items.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
+        asc(items.sortOrder),
+        asc(items.dateCompleted),
       );
+    return rows.map(toTask);
   });
 
 export const fetchCompletedTasks = createServerFn({ method: "GET" })
   .inputValidator(userIdInput)
   .handler(async ({ data }) => {
-    return db
-      .select(taskColumns)
-      .from(tasks)
-      .where(and(eq(tasks.userId, data.userId), isNotNull(tasks.dateCompleted)))
-      .orderBy(asc(tasks.dateCompleted));
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
+      .where(
+        and(
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          isNotNull(items.dateCompleted),
+        ),
+      )
+      .orderBy(asc(items.dateCompleted));
+    return rows.map(toTask);
   });
 
 export const completeTask = createServerFn({ method: "POST" })
@@ -157,13 +110,16 @@ export const completeTask = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Completing task ${data.taskId}...`);
 
-    const result = await db
-      .update(tasks)
-      .set({ dateCompleted: data.dateCompleted })
-      .where(and(eq(tasks.id, data.taskId), eq(tasks.userId, data.userId)))
+    const [result] = await db
+      .update(items)
+      .set({
+        dateCompleted: data.dateCompleted,
+        dateUpdated: new Date().toISOString(),
+      })
+      .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)))
       .returning();
 
-    return result[0];
+    return result;
   });
 
 export const updateTask = createServerFn({ method: "POST" })
@@ -185,26 +141,38 @@ export const updateTask = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Updating task ${data.id}...`);
 
-    const { id, userId, tagIds, ...updates } = data;
+    const {
+      id,
+      userId,
+      tagIds,
+      notes: content,
+      startDate: date,
+      ...rest
+    } = data;
+
+    // Map task field names → item field names
+    const updates: Record<string, unknown> = { ...rest };
+    if (content !== undefined) updates.content = content;
+    if (date !== undefined) updates.date = date;
 
     const result = await db.transaction(async (tx) => {
-      const [taskResult] = await tx
-        .update(tasks)
-        .set(updates)
-        .where(and(eq(tasks.id, id), eq(tasks.userId, userId)))
+      const [itemResult] = await tx
+        .update(items)
+        .set({ ...updates, dateUpdated: new Date().toISOString() })
+        .where(and(eq(items.id, id), eq(items.userId, userId)))
         .returning();
 
       if (tagIds !== undefined) {
-        await tx.delete(taskTags).where(eq(taskTags.taskId, id));
+        await tx.delete(itemTags).where(eq(itemTags.itemId, id));
 
         if (tagIds.length > 0) {
           await tx
-            .insert(taskTags)
-            .values(tagIds.map((tagId) => ({ taskId: id, tagId })));
+            .insert(itemTags)
+            .values(tagIds.map((tagId) => ({ itemId: id, tagId })));
         }
       }
 
-      return taskResult;
+      return itemResult;
     });
 
     return result;
@@ -220,7 +188,6 @@ export const reorderTasks = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Reordering ${data.taskIds.length} tasks...`);
 
-    // Generate fresh fractional keys for the entire reordered group
     const newKeys = generateNKeysBetween(null, null, data.taskIds.length);
 
     const valuesList = sql.join(
@@ -229,9 +196,9 @@ export const reorderTasks = createServerFn({ method: "POST" })
     );
 
     await db.execute(
-      sql`UPDATE tasks SET sort_order = v.sort_order
+      sql`UPDATE items SET sort_order = v.sort_order
           FROM (VALUES ${valuesList}) AS v(id, sort_order)
-          WHERE tasks.id = v.id AND tasks.user_id = ${data.userId}`,
+          WHERE items.id = v.id AND items.user_id = ${data.userId}`,
     );
   });
 
@@ -253,52 +220,64 @@ export const createTask = createServerFn({ method: "POST" })
     console.info("Creating task...");
 
     const id = `tsk_${crypto.randomUUID()}`;
+    const now = new Date().toISOString();
 
     const result = await db.transaction(async (tx) => {
-      // Get the max sortOrder for tasks in the same context (same date or backlog)
       const dateCondition = data.startDate
-        ? eq(tasks.startDate, data.startDate)
-        : isNull(tasks.startDate);
+        ? eq(items.date, data.startDate)
+        : isNull(items.date);
 
       const [maxRow] = await tx
-        .select({ max: sql<string | null>`MAX(${tasks.sortOrder})` })
-        .from(tasks)
+        .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+        .from(items)
         .where(
           and(
-            eq(tasks.userId, data.userId),
-            isNull(tasks.parentTaskId),
-            isNull(tasks.dateCompleted),
+            eq(items.userId, data.userId),
+            eq(items.type, "task"),
+            isNull(items.parentItemId),
+            isNull(items.dateCompleted),
             dateCondition,
           ),
         );
 
       const nextSortOrder = generateKeyBetween(maxRow?.max ?? null, null);
 
-      const [taskResult] = await tx
-        .insert(tasks)
+      const [itemResult] = await tx
+        .insert(items)
         .values({
           id,
+          type: "task",
           title: data.title,
-          notes: data.notes ?? null,
-          startDate: data.startDate ?? null,
-          parentTaskId: data.parentTaskId ?? null,
-          dateCreated: new Date().toISOString(),
+          content: data.notes ?? null,
+          date: data.startDate ?? null,
           dateCompleted: null,
-          userId: data.userId,
+          parentItemId: data.parentTaskId ?? null,
           sortOrder: nextSortOrder,
+          userId: data.userId,
+          dateCreated: now,
+          dateUpdated: now,
         })
         .returning();
 
       if (data.tagIds && data.tagIds.length > 0) {
         await tx
-          .insert(taskTags)
-          .values(data.tagIds.map((tagId) => ({ taskId: id, tagId })));
+          .insert(itemTags)
+          .values(data.tagIds.map((tagId) => ({ itemId: id, tagId })));
       }
 
-      return taskResult;
+      return itemResult;
     });
 
-    return result;
+    // Map raw item → Task shape
+    return {
+      ...result,
+      notes: result.content,
+      startDate: result.date,
+      parentTaskId: result.parentItemId,
+      subtaskCount: 0,
+      completedSubtaskCount: 0,
+      tags: [] as { id: string; name: string }[],
+    };
   });
 
 export const deleteTask = createServerFn({ method: "POST" })
@@ -313,17 +292,17 @@ export const deleteTask = createServerFn({ method: "POST" })
 
     await db.transaction(async (tx) => {
       await tx
-        .delete(tasks)
+        .delete(items)
         .where(
           and(
-            eq(tasks.parentTaskId, data.taskId),
-            eq(tasks.userId, data.userId),
+            eq(items.parentItemId, data.taskId),
+            eq(items.userId, data.userId),
           ),
         );
 
       await tx
-        .delete(tasks)
-        .where(and(eq(tasks.id, data.taskId), eq(tasks.userId, data.userId)));
+        .delete(items)
+        .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)));
     });
   });
 
@@ -341,19 +320,19 @@ export const moveTaskToDate = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     console.info(`Moving task ${data.taskId} to date ${data.date}...`);
 
-    // Find the max sortOrder among incomplete tasks on the target date
     const dateCondition = data.date
-      ? eq(tasks.startDate, data.date)
-      : isNull(tasks.startDate);
+      ? eq(items.date, data.date)
+      : isNull(items.date);
 
     const [maxRow] = await db
-      .select({ max: sql<string | null>`MAX(${tasks.sortOrder})` })
-      .from(tasks)
+      .select({ max: sql<string | null>`MAX(${items.sortOrder})` })
+      .from(items)
       .where(
         and(
-          eq(tasks.userId, data.userId),
-          isNull(tasks.parentTaskId),
-          isNull(tasks.dateCompleted),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          isNull(items.parentItemId),
+          isNull(items.dateCompleted),
           dateCondition,
         ),
       );
@@ -361,9 +340,13 @@ export const moveTaskToDate = createServerFn({ method: "POST" })
     const newKey = generateKeyBetween(maxRow?.max ?? null, null);
 
     const [result] = await db
-      .update(tasks)
-      .set({ startDate: data.date, sortOrder: newKey })
-      .where(and(eq(tasks.id, data.taskId), eq(tasks.userId, data.userId)))
+      .update(items)
+      .set({
+        date: data.date,
+        sortOrder: newKey,
+        dateUpdated: new Date().toISOString(),
+      })
+      .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)))
       .returning();
 
     return result;
@@ -377,10 +360,10 @@ export const fetchTaskWithRelations = createServerFn({ method: "GET" })
     }),
   )
   .handler(async ({ data }) => {
-    const result = await db.query.tasks.findFirst({
-      where: and(eq(tasks.id, data.taskId), eq(tasks.userId, data.userId)),
+    const result = await db.query.items.findFirst({
+      where: and(eq(items.id, data.taskId), eq(items.userId, data.userId)),
       with: {
-        taskTags: {
+        itemTags: {
           with: {
             tag: true,
           },
@@ -397,9 +380,16 @@ export const fetchTaskWithRelations = createServerFn({ method: "GET" })
 
     return {
       ...result,
-      tags: result.taskTags.map((tt) => tt.tag),
+      // Map to Task field names
+      notes: result.content,
+      startDate: result.date,
+      parentTaskId: result.parentItemId,
+      tags: result.itemTags.map((it) => it.tag),
       subtasks: result.subtasks.map((s) => ({
         ...s,
+        notes: s.content,
+        startDate: s.date,
+        parentTaskId: s.parentItemId,
         subtaskCount: 0,
         completedSubtaskCount: 0,
         tags: [] as { id: string; name: string }[],
@@ -417,29 +407,38 @@ export const fetchSubtasks = createServerFn({ method: "GET" })
     }),
   )
   .handler(async ({ data }) => {
-    return db
+    const rows = await db
       .select({
-        id: tasks.id,
-        title: tasks.title,
-        notes: tasks.notes,
-        dateCreated: tasks.dateCreated,
-        dateCompleted: tasks.dateCompleted,
-        startDate: tasks.startDate,
-        userId: tasks.userId,
-        parentTaskId: tasks.parentTaskId,
-        sortOrder: tasks.sortOrder,
+        id: items.id,
+        type: items.type,
+        title: items.title,
+        content: items.content,
+        date: items.date,
+        dateCompleted: items.dateCompleted,
+        parentItemId: items.parentItemId,
+        sortOrder: items.sortOrder,
+        userId: items.userId,
+        dateCreated: items.dateCreated,
+        dateUpdated: items.dateUpdated,
         subtaskCount: sql<number>`0`.as("subtask_count"),
         completedSubtaskCount: sql<number>`0`.as("completed_subtask_count"),
         tags: sql<{ id: string; name: string }[]>`'[]'::json`.as("tags"),
       })
-      .from(tasks)
+      .from(items)
       .where(
         and(
-          eq(tasks.parentTaskId, data.parentTaskId),
-          eq(tasks.userId, data.userId),
+          eq(items.parentItemId, data.parentTaskId),
+          eq(items.userId, data.userId),
         ),
       )
-      .orderBy(asc(tasks.dateCompleted), asc(tasks.dateCreated));
+      .orderBy(asc(items.dateCompleted), asc(items.dateCreated));
+
+    return rows.map((r) => ({
+      ...r,
+      notes: r.content,
+      startDate: r.date,
+      parentTaskId: r.parentItemId,
+    }));
   });
 
 // ─── Calendar & Day View queries ─────────────────────────────────────
@@ -457,47 +456,49 @@ export const fetchTasksForDate = createServerFn({ method: "GET" })
       await rollForwardStaleTasks(data.userId);
     }
 
-    return db
-      .select(taskColumns)
-      .from(tasks)
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
       .where(
         and(
-          eq(tasks.userId, data.userId),
-          isNull(tasks.parentTaskId),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          isNull(items.parentItemId),
           or(
-            // Incomplete tasks: only on their exact startDate
-            and(isNull(tasks.dateCompleted), eq(tasks.startDate, data.date)),
-            // Completed tasks: only on the day they were completed
+            and(isNull(items.dateCompleted), eq(items.date, data.date)),
             and(
-              isNotNull(tasks.dateCompleted),
-              eq(sql`CAST(${tasks.dateCompleted} AS date)`, data.date),
+              isNotNull(items.dateCompleted),
+              eq(sql`CAST(${items.dateCompleted} AS date)`, data.date),
             ),
           ),
         ),
       )
       .orderBy(
-        desc(isNull(tasks.dateCompleted)),
-        sql`CASE WHEN ${tasks.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
-        asc(tasks.sortOrder),
-        asc(tasks.dateCompleted),
+        desc(isNull(items.dateCompleted)),
+        sql`CASE WHEN ${items.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
+        asc(items.sortOrder),
+        asc(items.dateCompleted),
       );
+    return rows.map(toTask);
   });
 
 export const fetchBacklogTasks = createServerFn({ method: "GET" })
   .inputValidator(userIdInput)
   .handler(async ({ data }) => {
-    return db
-      .select(taskColumns)
-      .from(tasks)
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
       .where(
         and(
-          eq(tasks.userId, data.userId),
-          isNull(tasks.parentTaskId),
-          isNull(tasks.startDate),
-          isNull(tasks.dateCompleted),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          isNull(items.parentItemId),
+          isNull(items.date),
+          isNull(items.dateCompleted),
         ),
       )
-      .orderBy(asc(tasks.sortOrder));
+      .orderBy(asc(items.sortOrder));
+    return rows.map(toTask);
   });
 
 export const fetchTasksByTag = createServerFn({ method: "GET" })
@@ -513,22 +514,23 @@ export const fetchTasksByTag = createServerFn({ method: "GET" })
       .from(tags)
       .where(and(eq(tags.id, data.tagId), eq(tags.userId, data.userId)));
 
-    const taskList = await db
-      .select(taskColumns)
-      .from(tasks)
-      .innerJoin(taskTags, eq(taskTags.taskId, tasks.id))
+    const rows = await db
+      .select(itemColumns)
+      .from(items)
+      .innerJoin(itemTags, eq(itemTags.itemId, items.id))
       .where(
         and(
-          eq(tasks.userId, data.userId),
-          eq(taskTags.tagId, data.tagId),
-          isNull(tasks.parentTaskId),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+          eq(itemTags.tagId, data.tagId),
+          isNull(items.parentItemId),
         ),
       )
       .orderBy(
-        sql`CASE WHEN ${tasks.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
-        asc(tasks.sortOrder),
-        asc(tasks.dateCompleted),
+        sql`CASE WHEN ${items.dateCompleted} IS NOT NULL THEN 1 ELSE 0 END`,
+        asc(items.sortOrder),
+        asc(items.dateCompleted),
       );
 
-    return { tag: tag ?? null, tasks: taskList };
+    return { tag: tag ?? null, tasks: rows.map(toTask) };
   });

--- a/src/features/tasks/server.ts
+++ b/src/features/tasks/server.ts
@@ -116,7 +116,13 @@ export const completeTask = createServerFn({ method: "POST" })
         dateCompleted: data.dateCompleted,
         dateUpdated: new Date().toISOString(),
       })
-      .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)))
+      .where(
+        and(
+          eq(items.id, data.taskId),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+        ),
+      )
       .returning();
 
     return result;
@@ -159,10 +165,16 @@ export const updateTask = createServerFn({ method: "POST" })
       const [itemResult] = await tx
         .update(items)
         .set({ ...updates, dateUpdated: new Date().toISOString() })
-        .where(and(eq(items.id, id), eq(items.userId, userId)))
+        .where(
+          and(
+            eq(items.id, id),
+            eq(items.userId, userId),
+            eq(items.type, "task"),
+          ),
+        )
         .returning();
 
-      if (tagIds !== undefined) {
+      if (itemResult && tagIds !== undefined) {
         await tx.delete(itemTags).where(eq(itemTags.itemId, id));
 
         if (tagIds.length > 0) {
@@ -198,7 +210,7 @@ export const reorderTasks = createServerFn({ method: "POST" })
     await db.execute(
       sql`UPDATE items SET sort_order = v.sort_order
           FROM (VALUES ${valuesList}) AS v(id, sort_order)
-          WHERE items.id = v.id AND items.user_id = ${data.userId}`,
+          WHERE items.id = v.id AND items.user_id = ${data.userId} AND items.type = 'task'`,
     );
   });
 
@@ -297,12 +309,19 @@ export const deleteTask = createServerFn({ method: "POST" })
           and(
             eq(items.parentItemId, data.taskId),
             eq(items.userId, data.userId),
+            eq(items.type, "task"),
           ),
         );
 
       await tx
         .delete(items)
-        .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)));
+        .where(
+          and(
+            eq(items.id, data.taskId),
+            eq(items.userId, data.userId),
+            eq(items.type, "task"),
+          ),
+        );
     });
   });
 
@@ -346,7 +365,13 @@ export const moveTaskToDate = createServerFn({ method: "POST" })
         sortOrder: newKey,
         dateUpdated: new Date().toISOString(),
       })
-      .where(and(eq(items.id, data.taskId), eq(items.userId, data.userId)))
+      .where(
+        and(
+          eq(items.id, data.taskId),
+          eq(items.userId, data.userId),
+          eq(items.type, "task"),
+        ),
+      )
       .returning();
 
     return result;
@@ -429,6 +454,7 @@ export const fetchSubtasks = createServerFn({ method: "GET" })
         and(
           eq(items.parentItemId, data.parentTaskId),
           eq(items.userId, data.userId),
+          eq(items.type, "task"),
         ),
       )
       .orderBy(asc(items.dateCompleted), asc(items.dateCreated));

--- a/src/features/tasks/server.ts
+++ b/src/features/tasks/server.ts
@@ -125,7 +125,19 @@ export const completeTask = createServerFn({ method: "POST" })
       )
       .returning();
 
-    return result;
+    if (!result) return null;
+
+    return {
+      id: result.id,
+      title: result.title,
+      notes: result.content ?? null,
+      dateCreated: result.dateCreated,
+      dateCompleted: result.dateCompleted ?? null,
+      startDate: result.date ?? null,
+      userId: result.userId,
+      parentTaskId: result.parentItemId ?? null,
+      sortOrder: result.sortOrder,
+    };
   });
 
 export const updateTask = createServerFn({ method: "POST" })
@@ -386,7 +398,11 @@ export const fetchTaskWithRelations = createServerFn({ method: "GET" })
   )
   .handler(async ({ data }) => {
     const result = await db.query.items.findFirst({
-      where: and(eq(items.id, data.taskId), eq(items.userId, data.userId)),
+      where: and(
+        eq(items.id, data.taskId),
+        eq(items.userId, data.userId),
+        eq(items.type, "task"),
+      ),
       with: {
         itemTags: {
           with: {
@@ -433,22 +449,7 @@ export const fetchSubtasks = createServerFn({ method: "GET" })
   )
   .handler(async ({ data }) => {
     const rows = await db
-      .select({
-        id: items.id,
-        type: items.type,
-        title: items.title,
-        content: items.content,
-        date: items.date,
-        dateCompleted: items.dateCompleted,
-        parentItemId: items.parentItemId,
-        sortOrder: items.sortOrder,
-        userId: items.userId,
-        dateCreated: items.dateCreated,
-        dateUpdated: items.dateUpdated,
-        subtaskCount: sql<number>`0`.as("subtask_count"),
-        completedSubtaskCount: sql<number>`0`.as("completed_subtask_count"),
-        tags: sql<{ id: string; name: string }[]>`'[]'::json`.as("tags"),
-      })
+      .select(itemColumns)
       .from(items)
       .where(
         and(
@@ -459,12 +460,7 @@ export const fetchSubtasks = createServerFn({ method: "GET" })
       )
       .orderBy(asc(items.dateCompleted), asc(items.dateCreated));
 
-    return rows.map((r) => ({
-      ...r,
-      notes: r.content,
-      startDate: r.date,
-      parentTaskId: r.parentItemId,
-    }));
+    return rows.map(toTask);
   });
 
 // ─── Calendar & Day View queries ─────────────────────────────────────

--- a/src/routes/_app/tag/$tagId.tsx
+++ b/src/routes/_app/tag/$tagId.tsx
@@ -61,6 +61,7 @@ function TagView() {
   const { data } = useQuery(fetchTasksByTagQueryOptions(tagId));
   const { data: tagNotes = [] } = useQuery(fetchNotesByTagQueryOptions(tagId));
   const tagName = data?.tag?.name ?? "Tag";
+  const tagDescription = data?.tag?.description ?? null;
   const tasks = data?.tasks ?? [];
 
   const { mutate: updateTask } = useMutation(
@@ -90,6 +91,19 @@ function TagView() {
     if (editingTitle) titleInputRef.current?.focus();
   }, [editingTitle]);
 
+  // ─── Inline description editing ──────────────────────────────────
+  const [editingDescription, setEditingDescription] = useState(false);
+  const [descDraft, setDescDraft] = useState(tagDescription ?? "");
+  const descTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setDescDraft(tagDescription ?? "");
+  }, [tagDescription]);
+
+  useEffect(() => {
+    if (editingDescription) descTextareaRef.current?.focus();
+  }, [editingDescription]);
+
   function handleTitleSave() {
     const trimmed = titleDraft.trim();
     if (!trimmed) {
@@ -101,6 +115,15 @@ function TagView() {
     setEditingTitle(false);
     if (trimmed !== tagName) {
       updateTagMutation({ id: tagId, name: trimmed });
+    }
+  }
+
+  function handleDescriptionSave() {
+    const trimmed = descDraft.trim();
+    setEditingDescription(false);
+    const newDesc = trimmed || null;
+    if (newDesc !== tagDescription) {
+      updateTagMutation({ id: tagId, description: newDesc });
     }
   }
 
@@ -186,6 +209,42 @@ function TagView() {
             <PlusIcon className="size-5" />
           </Button>
         </header>
+
+        {/* Inline description editing */}
+        <div className="mt-1 pr-4 pl-8">
+          {editingDescription ? (
+            <textarea
+              ref={descTextareaRef}
+              value={descDraft}
+              placeholder="Add a description…"
+              onChange={(e) => setDescDraft(e.target.value)}
+              onBlur={handleDescriptionSave}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setDescDraft(tagDescription ?? "");
+                  setEditingDescription(false);
+                }
+              }}
+              className="text-muted-foreground w-full resize-none border-none bg-transparent text-sm outline-none"
+              rows={2}
+            />
+          ) : (
+            <p
+              role="button"
+              tabIndex={0}
+              className={`cursor-pointer text-sm ${tagDescription ? "text-muted-foreground" : "text-muted-foreground/50 italic"}`}
+              onClick={() => setEditingDescription(true)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setEditingDescription(true);
+                }
+              }}
+            >
+              {tagDescription || "Add a description…"}
+            </p>
+          )}
+        </div>
 
         <div className="mt-4">
           <DraggableList

--- a/src/routes/_app/tag/$tagId.tsx
+++ b/src/routes/_app/tag/$tagId.tsx
@@ -95,6 +95,7 @@ function TagView() {
   const [editingDescription, setEditingDescription] = useState(false);
   const [descDraft, setDescDraft] = useState(tagDescription ?? "");
   const descTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const descCancelledRef = useRef(false);
 
   useEffect(() => {
     setDescDraft(tagDescription ?? "");
@@ -119,6 +120,10 @@ function TagView() {
   }
 
   function handleDescriptionSave() {
+    if (descCancelledRef.current) {
+      descCancelledRef.current = false;
+      return;
+    }
     const trimmed = descDraft.trim();
     setEditingDescription(false);
     const newDesc = trimmed || null;
@@ -221,6 +226,7 @@ function TagView() {
               onBlur={handleDescriptionSave}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
+                  descCancelledRef.current = true;
                   setDescDraft(tagDescription ?? "");
                   setEditingDescription(false);
                 }
@@ -229,20 +235,13 @@ function TagView() {
               rows={2}
             />
           ) : (
-            <p
-              role="button"
-              tabIndex={0}
-              className={`cursor-pointer text-sm ${tagDescription ? "text-muted-foreground" : "text-muted-foreground/50 italic"}`}
+            <button
+              type="button"
+              className={`cursor-pointer text-left text-sm ${tagDescription ? "text-muted-foreground" : "text-muted-foreground/50 italic"}`}
               onClick={() => setEditingDescription(true)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setEditingDescription(true);
-                }
-              }}
             >
               {tagDescription || "Add a description…"}
-            </p>
+            </button>
           )}
         </div>
 

--- a/src/tests/start.test.tsx
+++ b/src/tests/start.test.tsx
@@ -13,7 +13,7 @@ test("requests are mocked", async () => {
       startDate: null,
       userId: "1",
       parentTaskId: null,
-      sortOrder: 0,
+      sortOrder: "a0",
       subtaskCount: 0,
       completedSubtaskCount: 0,
       tags: [],


### PR DESCRIPTION
This pull request implements a major database refactor to unify tasks, notes, and events into a single `items` table, along with related schema and documentation updates. The unified architecture simplifies data management and enables advanced features like reminders and recurrence to be attached to any item type. Legacy tables are deprecated and only retained for migration reference.

**Unified Items Architecture and Schema Refactor:**

* Introduced a new `items` table to store tasks, notes, and events, differentiated by a `type` column. Related tables (`item_tags`, `item_metadata`, `schedules`, `schedule_history`, `push_subscriptions`) were added to support tags, AI metadata, reminders, and push notifications for all item types. [[1]](diffhunk://#diff-6c03f61f5a30893704f187e6b9ceb24f2c4e3b0782fff1d299a6020a9bb9cb98R1-R130) [[2]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL37-R198)
* Migration script created to move all existing data from `tasks`, `notes`, and related tables into the new unified structure, preserving data integrity and relationships. Old tables are dropped after migration.
* Updated Drizzle schema (`src/db/schema.ts`) to define the new tables and relations, and marked legacy tables as deprecated for migration purposes. [[1]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL37-R198) [[2]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL60-R220) [[3]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL75-R246) [[4]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL103-L167)

**Documentation and Developer Experience:**

* Updated `.github/copilot-instructions.md` to describe the unified items architecture, new table structure, and updated folder organization (including thin adapters for tasks/notes/events and new schedules feature). [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L7-R7) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R65-R76)
* Documented new React Query key patterns to support filtering by item type.

**Supporting Changes:**

* Updated the database seed script to use the new unified tables.
* Registered the new migration in the Drizzle migration journal.
* Minor Playwright config tweak to prevent auto-opening HTML reports.