### PR TITLE
feat: implement reminder functionality in Task and Note dialogs, add ItemSchedulesSection component

### DIFF
--- a/.github/PLAN.md
+++ b/.github/PLAN.md
@@ -656,12 +656,12 @@ The app has a small dataset, the schema is young, and we're about to add a third
 
 > Create the thin events adapter over the unified items table. No UI, no routes — just the data layer following the exact same pattern as `features/tasks/` and `features/notes/`.
 
-- [ ] Create `src/features/events/types.ts`:
+- [x] Create `src/features/events/types.ts`:
   - `Event` type (narrowed from `Item` where `type === 'event'`)
   - `EventWithSchedule` type — event with its attached schedule(s)
-- [ ] Create `src/features/events/consts.ts`:
+- [x] Create `src/features/events/consts.ts`:
   - Query keys: `eventsQueryKeys` (all, byId, byDate, byTag)
-- [ ] Create `src/features/events/server.ts`:
+- [x] Create `src/features/events/server.ts`:
   - `fetchEvents(userId)` — all events, ordered by dateCreated DESC
   - `fetchEventsForDate(userId, date)` — events where `date` matches
   - `fetchEventsByTag(userId, tagId)` — events with a specific tag
@@ -669,12 +669,12 @@ The app has a small dataset, the schema is young, and we're about to add a third
   - `createEvent({ title, content?, date?, tagIds? })` — creates item with `type: 'event'`, `evt_` prefixed ID
   - `updateEvent({ id, title?, content?, date?, tagIds? })` — tag sync in transaction
   - `deleteEvent(eventId)` — hard delete
-- [ ] Create `src/features/events/queries.ts` — React Query option factories wrapping server functions
-- [ ] Create `src/features/events/mutations.ts` — React Query mutations with optimistic updates (same pattern as tasks/notes)
-- [ ] Update `src/db/seed.ts` — add sample event items (2-3 events with tags)
-- [ ] **Verify**: `pnpm typecheck` passes
-- [ ] **Verify**: `pnpm test` passes (no regressions)
-- [ ] **Verify**: `pnpm db:seed` creates sample events
+- [x] Create `src/features/events/queries.ts` — React Query option factories wrapping server functions
+- [x] Create `src/features/events/mutations.ts` — React Query mutations with optimistic updates (same pattern as tasks/notes)
+- [x] Update `src/db/seed.ts` — add sample event items (2-3 events with tags)
+- [x] **Verify**: `pnpm typecheck` passes
+- [x] **Verify**: `pnpm test` passes (no regressions)
+- [x] **Verify**: `pnpm db:seed` creates sample events
 
 #### Outputs
 
@@ -736,7 +736,7 @@ The app has a small dataset, the schema is young, and we're about to add a third
 
 > Build the `/reminders` route and the core UI components. This is the first visible change — users can see, create, edit, and delete reminders. No push notifications yet — just CRUD and display.
 
-- [ ] Build `src/components/ReminderItem.tsx` — list item for reminders:
+- [x] Build `src/components/ReminderItem.tsx` — list item for reminders:
   - Bell icon (plain event) or checkbox-clock icon (cloneOnFire)
   - Title as primary text
   - Next occurrence datetime (relative: "in 2 hours", "tomorrow at 9am")
@@ -744,13 +744,13 @@ The app has a small dataset, the schema is young, and we're about to add a third
   - Tag badges (same styling as TaskItem)
   - Actions: Edit, Delete
   - Missed indicator for past-due (muted "Overdue" badge)
-- [ ] Build `src/components/RecurrencePicker.tsx` — embedded in ReminderDialog:
+- [x] Build `src/components/RecurrencePicker.tsx` — embedded in ReminderDialog:
   - Preset buttons: None, Daily, Weekly, Monthly, Custom
   - Weekly → day-of-week checkboxes (Mon–Sun)
   - Monthly → day-of-month select
   - Custom → interval number + unit (days/weeks/months)
   - Human-readable preview below
-- [ ] Build `src/components/ReminderDialog.tsx` — create/edit reminder:
+- [x] Build `src/components/ReminderDialog.tsx` — create/edit reminder:
   - **Title** (text input, required)
   - **Description** (textarea, optional → stored as `content`)
   - **Generates task** toggle — sets `cloneOnFire`. Explanation: "Creates a new task each time this fires"
@@ -758,19 +758,19 @@ The app has a small dataset, the schema is young, and we're about to add a third
   - **RecurrencePicker** component
   - **Tags** — `TagMultiSelect` (reused)
   - On save: calls `createEventWithSchedule` or updates existing
-- [ ] Create `/reminders` route (`src/routes/_app/reminders.tsx`):
+- [x] Create `/reminders` route (`src/routes/_app/reminders.tsx`):
   - Upcoming section: chronological list of events with active schedules, grouped by day (Today, Tomorrow, This Week, Later)
   - "+" button → ReminderDialog
   - Route loader: `ensureQueryData` for upcoming schedules
   - Page head: `title: "Reminders - whatIdid"`
-- [ ] Update `src/routes/_app.tsx`:
+- [x] Update `src/routes/_app.tsx`:
   - Add "Reminders" to `navItems`: `{ to: '/reminders', label: 'Reminders' }`
-- [ ] Update `src/components/AppLayoutContext.tsx`:
+- [x] Update `src/components/AppLayoutContext.tsx`:
   - Add `reminderDialogOpen`, `editingEvent`, `handleOpenReminderDialog` to layout context
-- [ ] **Verify**: `pnpm typecheck` passes
-- [ ] **Verify**: `pnpm test` passes
-- [ ] **Verify**: `pnpm test:e2e` passes (existing tests — no new E2E yet)
-- [ ] **Verify**: Can create, view, edit, and delete reminders via the UI
+- [x] **Verify**: `pnpm typecheck` passes
+- [x] **Verify**: `pnpm test` passes
+- [x] **Verify**: `pnpm test:e2e` passes (existing tests — no new E2E yet)
+- [x] **Verify**: Can create, view, edit, and delete reminders via the UI
 
 #### Outputs
 
@@ -818,19 +818,21 @@ The app has a small dataset, the schema is young, and we're about to add a third
 
 > Allow setting reminders on existing tasks and notes from their edit dialogs.
 
-- [ ] Add "Set Reminder" section to `TaskDialog.tsx`:
+- [x] Add "Set Reminder" section to `TaskDialog.tsx`:
   - Collapsible section with datetime + optional recurrence
   - Creates a schedule attached to the task item (no new event created)
   - Shows existing schedules on the task if any
-- [ ] Add "Set Reminder" section to `NoteDialog.tsx`:
+- [x] Add "Set Reminder" section to `NoteDialog.tsx`:
   - Same pattern — schedule attached to the note item
-- [ ] Add bell indicator on `TaskItem.tsx` for tasks that have schedules
-- [ ] Add bell indicator on `NoteItem.tsx` for notes that have schedules
-- [ ] **Verify**: `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` all pass
+- [x] Add bell indicator on `TaskItem.tsx` for tasks that have schedules
+- [x] Add bell indicator on `NoteItem.tsx` for notes that have schedules
+- [x] **Verify**: `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` all pass
 
 #### Outputs
 
+- New: `src/components/ItemSchedulesSection.tsx` — reusable list + add-form for schedules attached to an item
 - Updated: `TaskDialog.tsx`, `NoteDialog.tsx`, `TaskItem.tsx`, `NoteItem.tsx`
+- Updated: `DayView.tsx`, `routes/_app/backlog.tsx`, `routes/_app/notes.tsx` — wire `hasReminder` from `schedulesQueryOptions()`
 
 ---
 

--- a/src/components/DayView.tsx
+++ b/src/components/DayView.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { PlusIcon } from "lucide-react";
-import { useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { useAppLayout } from "~/components/AppLayoutContext";
 import { DraggableList } from "~/components/DraggableTaskList";
 import { NoteItem } from "~/components/NoteItem";
@@ -19,6 +19,7 @@ import {
 } from "~/features/tasks/mutations";
 import { fetchTasksForDateQueryOptions } from "~/features/tasks/queries";
 import { Task } from "~/features/tasks/types";
+import { schedulesQueryOptions } from "~/features/schedules/queries";
 
 interface DayViewProps {
   selectedDate: Date;
@@ -38,6 +39,11 @@ export function DayView({
   const { data: tasks = [] } = useQuery(fetchTasksForDateQueryOptions(dateStr));
   const { data: dayNotes = [] } = useQuery(
     fetchNotesForDateQueryOptions(dateStr),
+  );
+  const { data: allSchedules = [] } = useQuery(schedulesQueryOptions());
+  const itemsWithReminder = useMemo(
+    () => new Set(allSchedules.map((s) => s.itemId)),
+    [allSchedules],
   );
 
   const { mutate: updateTask } = useMutation(
@@ -116,6 +122,7 @@ export function DayView({
                   onDelete={handleDelete}
                   isDragging={false}
                   hideEmptyNotes
+                  hasReminder={itemsWithReminder.has(task.id)}
                 />
               )}
             >
@@ -130,6 +137,7 @@ export function DayView({
                   dragAttributes={dragAttributes}
                   dragListeners={dragListeners}
                   hideEmptyNotes
+                  hasReminder={itemsWithReminder.has(task.id)}
                 />
               )}
             </SortableTaskList>
@@ -144,6 +152,7 @@ export function DayView({
                   onDelete={handleDelete}
                   isDragging={false}
                   hideEmptyNotes
+                  hasReminder={itemsWithReminder.has(task.id)}
                 />
               ))}
             </ul>
@@ -172,6 +181,7 @@ export function DayView({
                   isDragging={isDragging}
                   dragAttributes={dragAttributes}
                   dragListeners={dragListeners}
+                  hasReminder={itemsWithReminder.has(note.id)}
                 />
               )}
             </DraggableList>

--- a/src/components/ItemSchedulesSection.tsx
+++ b/src/components/ItemSchedulesSection.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   useEffect,
+  useId,
   useImperativeHandle,
   useRef,
   useState,
@@ -63,6 +64,11 @@ export const ItemSchedulesSection = forwardRef<
   const [reminderTime, setReminderTime] = useState(defaultNextHour);
   const [rrule, setRrule] = useState<string | null>(null);
 
+  // Unique per mounted instance so multiple dialogs/sections can coexist
+  // without colliding on the same DOM id (which breaks label association).
+  const reactId = useId();
+  const dateTimeFieldId = `item-schedule-time-${reactId}`;
+
   const { mutateAsync: createSchedule, isPending: isCreating } =
     useCreateSchedule();
   const { mutate: deleteSchedule } = useDeleteSchedule();
@@ -87,16 +93,33 @@ export const ItemSchedulesSection = forwardRef<
     setRrule(null);
   }
 
+  // Guard against duplicate creation when the user clicks "Add reminder"
+  // and then quickly clicks the parent dialog Save: both paths funnel into
+  // `commitPending`, but only one mutation should fire per pending entry.
+  const inFlightRef = useRef(false);
+
   async function commitPending() {
+    if (inFlightRef.current) return;
     const { adding: a, reminderTime: t, rrule: r } = stateRef.current;
     if (!a || !t) return;
-    await createScheduleRef.current({
-      itemId,
-      reminderTime: new Date(t).toISOString(),
-      rrule: r ?? undefined,
-    });
-    resetForm();
+    inFlightRef.current = true;
+    // Optimistically collapse the form so a second click can't re-enter via
+    // the inline button while the mutation is in flight.
     setAdding(false);
+    try {
+      await createScheduleRef.current({
+        itemId,
+        reminderTime: new Date(t).toISOString(),
+        rrule: r ?? undefined,
+      });
+      resetForm();
+    } catch (err) {
+      // Restore the form so the user can retry / edit.
+      setAdding(true);
+      throw err;
+    } finally {
+      inFlightRef.current = false;
+    }
   }
 
   useImperativeHandle(ref, () => ({ commitPending }));
@@ -124,44 +147,53 @@ export const ItemSchedulesSection = forwardRef<
 
       {schedules.length > 0 && (
         <ul className="space-y-1">
-          {schedules.map((s) => (
-            <li
-              key={s.id}
-              className="border-border/50 group/sch flex items-center gap-2 rounded-md border px-2 py-1.5"
-            >
-              <BellIcon className="text-muted-foreground/70 size-4 shrink-0" />
-              <div className="flex min-w-0 flex-1 flex-col">
-                <span className="truncate text-xs">
-                  {format(new Date(s.reminderTime), "PPp")}
-                </span>
-                {s.rrule && (
-                  <span className="text-muted-foreground truncate text-xs capitalize">
-                    {describeRRule(s.rrule)}
-                  </span>
-                )}
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="size-7 opacity-0 group-hover/sch:opacity-100"
-                onClick={() => deleteSchedule(s.id)}
-                aria-label="Delete reminder"
-                title="Delete reminder"
+          {schedules.map((s) => {
+            const effectiveTime = s.snoozedUntil ?? s.reminderTime;
+            const isSnoozed = s.status === "snoozed" && !!s.snoozedUntil;
+            return (
+              <li
+                key={s.id}
+                className="border-border/50 group/sch flex items-center gap-2 rounded-md border px-2 py-1.5"
               >
-                <Trash2Icon className="size-3.5" />
-              </Button>
-            </li>
-          ))}
+                <BellIcon className="text-muted-foreground/70 size-4 shrink-0" />
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-xs">
+                    {format(new Date(effectiveTime), "PPp")}
+                    {isSnoozed && (
+                      <span className="text-muted-foreground ml-1">
+                        (snoozed)
+                      </span>
+                    )}
+                  </span>
+                  {s.rrule && (
+                    <span className="text-muted-foreground truncate text-xs capitalize">
+                      {describeRRule(s.rrule)}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="size-7 opacity-0 group-hover/sch:opacity-100"
+                  onClick={() => deleteSchedule(s.id)}
+                  aria-label="Delete reminder"
+                  title="Delete reminder"
+                >
+                  <Trash2Icon className="size-3.5" />
+                </Button>
+              </li>
+            );
+          })}
         </ul>
       )}
 
       {adding && (
         <div className="border-border/50 space-y-3 rounded-md border p-3">
           <div className="space-y-1.5">
-            <Label htmlFor="item-schedule-time">Date &amp; Time</Label>
+            <Label htmlFor={dateTimeFieldId}>Date &amp; Time</Label>
             <DateTimePicker
-              id="item-schedule-time"
+              id={dateTimeFieldId}
               value={reminderTime}
               onChange={setReminderTime}
             />

--- a/src/components/ItemSchedulesSection.tsx
+++ b/src/components/ItemSchedulesSection.tsx
@@ -1,0 +1,201 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { BellIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+import { DateTimePicker } from "~/components/DateTimePicker";
+import { RecurrencePicker } from "~/components/RecurrencePicker";
+import {
+  useCreateSchedule,
+  useDeleteSchedule,
+} from "~/features/schedules/mutations";
+import { schedulesForItemQueryOptions } from "~/features/schedules/queries";
+import { describeRRule } from "~/features/schedules/recurrence";
+
+interface ItemSchedulesSectionProps {
+  itemId: string;
+}
+
+/**
+ * Imperative API exposed via ref so the parent dialog can commit any pending
+ * (in-progress, unsaved) reminder when the user submits the parent form. The
+ * inline "Add reminder" button still works for explicit commits, but the
+ * common flow is to fill the form and click the parent Save button — we
+ * don't want to silently discard the user's input in that case.
+ */
+export interface ItemSchedulesSectionHandle {
+  commitPending: () => Promise<void>;
+}
+
+function toLocalDatetimeValue(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function defaultNextHour(): string {
+  const d = new Date();
+  d.setHours(d.getHours() + 1, 0, 0, 0);
+  return toLocalDatetimeValue(d.toISOString());
+}
+
+/**
+ * Inline reminders manager for an existing item (task or note). Lists
+ * existing schedules attached to the item and lets the user attach a new
+ * one. Used inside TaskDialog and NoteDialog.
+ */
+export const ItemSchedulesSection = forwardRef<
+  ItemSchedulesSectionHandle,
+  ItemSchedulesSectionProps
+>(function ItemSchedulesSection({ itemId }, ref) {
+  const { data: schedules = [] } = useQuery(
+    schedulesForItemQueryOptions(itemId),
+  );
+
+  const [adding, setAdding] = useState(false);
+  const [reminderTime, setReminderTime] = useState(defaultNextHour);
+  const [rrule, setRrule] = useState<string | null>(null);
+
+  const { mutateAsync: createSchedule, isPending: isCreating } =
+    useCreateSchedule();
+  const { mutate: deleteSchedule } = useDeleteSchedule();
+
+  // Mirror the latest form state + mutation into refs so the imperative
+  // `commitPending` always sees current values without rebinding on every
+  // keystroke. Writes happen in an effect so we don't mutate refs during
+  // render (react-hooks/refs).
+  const stateRef = useRef({ adding, reminderTime, rrule });
+  const createScheduleRef = useRef(createSchedule);
+
+  useEffect(() => {
+    stateRef.current = { adding, reminderTime, rrule };
+  }, [adding, reminderTime, rrule]);
+
+  useEffect(() => {
+    createScheduleRef.current = createSchedule;
+  }, [createSchedule]);
+
+  function resetForm() {
+    setReminderTime(defaultNextHour());
+    setRrule(null);
+  }
+
+  async function commitPending() {
+    const { adding: a, reminderTime: t, rrule: r } = stateRef.current;
+    if (!a || !t) return;
+    await createScheduleRef.current({
+      itemId,
+      reminderTime: new Date(t).toISOString(),
+      rrule: r ?? undefined,
+    });
+    resetForm();
+    setAdding(false);
+  }
+
+  useImperativeHandle(ref, () => ({ commitPending }));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>Reminders</Label>
+        {!adding && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setAdding(true)}
+          >
+            <PlusIcon className="size-3.5" />
+            Add
+          </Button>
+        )}
+      </div>
+
+      {schedules.length === 0 && !adding && (
+        <p className="text-muted-foreground text-xs">No reminders set.</p>
+      )}
+
+      {schedules.length > 0 && (
+        <ul className="space-y-1">
+          {schedules.map((s) => (
+            <li
+              key={s.id}
+              className="border-border/50 group/sch flex items-center gap-2 rounded-md border px-2 py-1.5"
+            >
+              <BellIcon className="text-muted-foreground/70 size-4 shrink-0" />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-xs">
+                  {format(new Date(s.reminderTime), "PPp")}
+                </span>
+                {s.rrule && (
+                  <span className="text-muted-foreground truncate text-xs capitalize">
+                    {describeRRule(s.rrule)}
+                  </span>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 opacity-0 group-hover/sch:opacity-100"
+                onClick={() => deleteSchedule(s.id)}
+                aria-label="Delete reminder"
+                title="Delete reminder"
+              >
+                <Trash2Icon className="size-3.5" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {adding && (
+        <div className="border-border/50 space-y-3 rounded-md border p-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="item-schedule-time">Date &amp; Time</Label>
+            <DateTimePicker
+              id="item-schedule-time"
+              value={reminderTime}
+              onChange={setReminderTime}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Repeat</Label>
+            <RecurrencePicker value={rrule} onChange={setRrule} />
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Saved when you click Save below.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                resetForm();
+                setAdding(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={isCreating || !reminderTime}
+              onClick={commitPending}
+            >
+              Add reminder
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/components/NoteDialog.tsx
+++ b/src/components/NoteDialog.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useRef } from "react";
+import { useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Drawer,

--- a/src/components/NoteDialog.tsx
+++ b/src/components/NoteDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Drawer,
@@ -13,6 +14,10 @@ import { Label } from "~/components/ui/label";
 import { TagMultiSelect } from "~/components/TagMultiSelect";
 import { MarkdownEditor } from "~/components/MarkdownEditor";
 import { DateTimePicker } from "~/components/DateTimePicker";
+import {
+  ItemSchedulesSection,
+  type ItemSchedulesSectionHandle,
+} from "~/components/ItemSchedulesSection";
 import {
   useCreateNote,
   useProcessNoteWithAI,
@@ -116,6 +121,8 @@ function NoteDialogForm({
   const { mutateAsync: updateNote, isPending: isUpdating } = useUpdateNote();
   const { mutate: triggerAI } = useProcessNoteWithAI();
 
+  const schedulesSectionRef = useRef<ItemSchedulesSectionHandle>(null);
+
   const isPending = isCreating || isUpdating;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -130,6 +137,10 @@ function NoteDialogForm({
         date: date || null,
         tagIds,
       });
+
+      // Persist any in-progress reminder the user typed but didn't
+      // explicitly click "Add reminder" for.
+      await schedulesSectionRef.current?.commitPending();
 
       // Re-trigger AI if content changed and title was AI-generated (user didn't set one)
       if (content.trim() !== note.content && !title.trim()) {
@@ -214,6 +225,16 @@ function NoteDialogForm({
               <Label>Tags</Label>
               <TagMultiSelect selectedTagIds={tagIds} onChange={setTagIds} />
             </div>
+
+            {/* Reminders (only in edit mode — schedules attach to existing items) */}
+            {isEditing && note && (
+              <div className="space-y-1.5 px-4">
+                <ItemSchedulesSection
+                  ref={schedulesSectionRef}
+                  itemId={note.id}
+                />
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/TaskDialog.tsx
+++ b/src/components/TaskDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Drawer,
@@ -13,6 +14,10 @@ import { Label } from "~/components/ui/label";
 import { TagMultiSelect } from "~/components/TagMultiSelect";
 import { MarkdownEditor } from "~/components/MarkdownEditor";
 import { DateTimePicker } from "~/components/DateTimePicker";
+import {
+  ItemSchedulesSection,
+  type ItemSchedulesSectionHandle,
+} from "~/components/ItemSchedulesSection";
 import { SubtaskList } from "~/components/SubtaskList";
 import {
   useCreateTask,
@@ -122,6 +127,8 @@ function TaskDialogForm({
   const { mutate: completeSubtask } = useCompleteTask();
   const { mutate: deleteSubtask } = useDeleteTask();
 
+  const schedulesSectionRef = useRef<ItemSchedulesSectionHandle>(null);
+
   const isPending = isCreating || isUpdating;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -136,6 +143,9 @@ function TaskDialogForm({
         startDate: startDate || null,
         tagIds,
       });
+      // Persist any in-progress reminder the user typed but didn't
+      // explicitly click "Add reminder" for.
+      await schedulesSectionRef.current?.commitPending();
     } else {
       await createTask({
         title: title.trim(),
@@ -258,6 +268,16 @@ function TaskDialogForm({
                   onAdd={handleAddSubtask}
                   onComplete={handleCompleteSubtask}
                   onDelete={handleDeleteSubtask}
+                />
+              </div>
+            )}
+
+            {/* Reminders (only in edit mode — schedules attach to existing items) */}
+            {isEditing && task && (
+              <div className="space-y-1.5 px-4">
+                <ItemSchedulesSection
+                  ref={schedulesSectionRef}
+                  itemId={task.id}
                 />
               </div>
             )}

--- a/src/components/TaskDialog.tsx
+++ b/src/components/TaskDialog.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Drawer,

--- a/src/features/schedules/mutations.ts
+++ b/src/features/schedules/mutations.ts
@@ -25,8 +25,14 @@ export function useCreateSchedule() {
   return useMutation({
     mutationFn: (input: CreateScheduleInput) =>
       createSchedule({ data: { ...input, userId: DEFAULT_USER_ID } }),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: schedulesQueryKeys.all });
+      // Explicit per-item invalidation — `all` already prefix-matches
+      // `byItem`, but spell it out so callers (e.g. ItemSchedulesSection)
+      // are guaranteed a refetch even if key shapes change later.
+      queryClient.invalidateQueries({
+        queryKey: schedulesQueryKeys.byItem(variables.itemId),
+      });
     },
   });
 }

--- a/src/features/schedules/server.ts
+++ b/src/features/schedules/server.ts
@@ -147,14 +147,24 @@ export const fetchSchedulesForItem = createServerFn({ method: "GET" })
     }),
   )
   .handler(async ({ data }) => {
+    // Only surface schedules that still affect the user (active or snoozed).
+    // Dismissed/completed rows stay in the DB for history but shouldn't drive
+    // the inline reminders list — that would diverge from the bell indicator,
+    // which is computed from the active+snoozed list via `fetchSchedules`.
+    // Order by the effective fire time (snoozedUntil takes precedence) so
+    // a snoozed schedule shows up where it will actually fire next.
     const results = await db
       .select()
       .from(schedules)
       .innerJoin(items, eq(items.id, schedules.itemId))
       .where(
-        and(eq(schedules.itemId, data.itemId), eq(items.userId, data.userId)),
+        and(
+          eq(schedules.itemId, data.itemId),
+          eq(items.userId, data.userId),
+          inArray(schedules.status, ["active", "snoozed"]),
+        ),
       )
-      .orderBy(asc(schedules.reminderTime));
+      .orderBy(asc(effectiveFireTime));
 
     return results.map((r) => toSchedule(r.schedules));
   });

--- a/src/routes/_app/backlog.tsx
+++ b/src/routes/_app/backlog.tsx
@@ -21,7 +21,10 @@ export const Route = createFileRoute("/_app/backlog")({
     meta: [{ title: "Backlog - whatIdid" }],
   }),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(fetchBacklogTasksQueryOptions());
+    await Promise.all([
+      context.queryClient.ensureQueryData(fetchBacklogTasksQueryOptions()),
+      context.queryClient.ensureQueryData(schedulesQueryOptions()),
+    ]);
     return null;
   },
   component: Backlog,

--- a/src/routes/_app/backlog.tsx
+++ b/src/routes/_app/backlog.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
-import { useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { useAppLayout } from "~/components/AppLayoutContext";
 import { SortableTaskList } from "~/components/SortableTaskList";
 import { TaskItem } from "~/components/TaskItem";
@@ -14,6 +14,7 @@ import {
 } from "~/features/tasks/mutations";
 import { fetchBacklogTasksQueryOptions } from "~/features/tasks/queries";
 import { Task } from "~/features/tasks/types";
+import { schedulesQueryOptions } from "~/features/schedules/queries";
 
 export const Route = createFileRoute("/_app/backlog")({
   head: () => ({
@@ -30,6 +31,11 @@ function Backlog() {
   const { setDragOverDate, handleOpenDialog } = useAppLayout();
 
   const { data: tasks = [] } = useQuery(fetchBacklogTasksQueryOptions());
+  const { data: allSchedules = [] } = useQuery(schedulesQueryOptions());
+  const itemsWithReminder = useMemo(
+    () => new Set(allSchedules.map((s) => s.itemId)),
+    [allSchedules],
+  );
 
   const { mutate: updateTask } = useMutation(
     useUpdateTaskMutationOptions({ onError: () => {} }),
@@ -90,6 +96,7 @@ function Backlog() {
                   hideEmptyNotes
                   dragAttributes={dragAttributes}
                   dragListeners={dragListeners}
+                  hasReminder={itemsWithReminder.has(task.id)}
                 />
               )}
             </SortableTaskList>
@@ -103,6 +110,7 @@ function Backlog() {
                   onEdit={handleEdit}
                   onDelete={handleDelete}
                   isDragging={false}
+                  hasReminder={itemsWithReminder.has(task.id)}
                 />
               ))}
             </ul>

--- a/src/routes/_app/day/$date.tsx
+++ b/src/routes/_app/day/$date.tsx
@@ -3,6 +3,7 @@ import { format, isValid, parseISO } from "date-fns";
 import { useAppLayout } from "~/components/AppLayoutContext";
 import { DayView } from "~/components/DayView";
 import { fetchNotesForDateQueryOptions } from "~/features/notes/queries";
+import { schedulesQueryOptions } from "~/features/schedules/queries";
 import { fetchTasksForDateQueryOptions } from "~/features/tasks/queries";
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -26,6 +27,7 @@ export const Route = createFileRoute("/_app/day/$date")({
       context.queryClient.ensureQueryData(
         fetchNotesForDateQueryOptions(params.date),
       ),
+      context.queryClient.ensureQueryData(schedulesQueryOptions()),
     ]);
     return null;
   },

--- a/src/routes/_app/notes.tsx
+++ b/src/routes/_app/notes.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAppLayout } from "~/components/AppLayoutContext";
 import { DraggableList } from "~/components/DraggableTaskList";
 import { NoteItem } from "~/components/NoteItem";
@@ -13,6 +13,7 @@ import {
   searchNotesQueryOptions,
 } from "~/features/notes/queries";
 import { Note } from "~/features/notes/types";
+import { schedulesQueryOptions } from "~/features/schedules/queries";
 
 export const Route = createFileRoute("/_app/notes")({
   head: () => ({
@@ -57,6 +58,12 @@ function NotesView() {
 
   const { mutate: deleteNoteMutation } = useDeleteNote();
   const { mutate: updateNoteMutation } = useUpdateNote();
+
+  const { data: allSchedules = [] } = useQuery(schedulesQueryOptions());
+  const itemsWithReminder = useMemo(
+    () => new Set(allSchedules.map((s) => s.itemId)),
+    [allSchedules],
+  );
 
   function handleEdit(note: Note) {
     handleOpenNoteDialog(note);
@@ -112,6 +119,7 @@ function NotesView() {
                   isDragging={isDragging}
                   dragAttributes={dragAttributes}
                   dragListeners={dragListeners}
+                  hasReminder={itemsWithReminder.has(note.id)}
                 />
               )}
             </DraggableList>

--- a/src/routes/_app/notes.tsx
+++ b/src/routes/_app/notes.tsx
@@ -20,7 +20,10 @@ export const Route = createFileRoute("/_app/notes")({
     meta: [{ title: "Notes - whatIdid" }],
   }),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(fetchNotesQueryOptions(1));
+    await Promise.all([
+      context.queryClient.ensureQueryData(fetchNotesQueryOptions(1)),
+      context.queryClient.ensureQueryData(schedulesQueryOptions()),
+    ]);
     return null;
   },
   component: NotesView,


### PR DESCRIPTION
This pull request implements reminders (schedules) for tasks and notes, introduces a reusable schedules section component, and wires up the UI to display and manage reminders throughout the app. The main changes include adding the ability to set, view, and delete reminders on tasks and notes, updating the `/reminders` route and UI, and ensuring all relevant queries and mutations are in place. The implementation follows the existing patterns for tasks and notes, and all relevant tests and type checks pass.

**Reminders and Schedules Functionality**

* Added `ItemSchedulesSection` component for managing reminders (schedules) attached to a task or note, with imperative API for committing pending reminders from parent dialogs. (`src/components/ItemSchedulesSection.tsx`)
* Updated `TaskDialog.tsx` and `NoteDialog.tsx` to include a "Set Reminder" section using `ItemSchedulesSection`, ensuring in-progress reminders are saved on form submit. (`src/components/TaskDialog.tsx`, `src/components/NoteDialog.tsx`) [[1]](diffhunk://#diff-1b0370815e0dc95e203ad256cde5983377e01867730f5387bbd212dbf76b943bR17-R20) [[2]](diffhunk://#diff-1b0370815e0dc95e203ad256cde5983377e01867730f5387bbd212dbf76b943bR130-R131) [[3]](diffhunk://#diff-1b0370815e0dc95e203ad256cde5983377e01867730f5387bbd212dbf76b943bR146-R148) [[4]](diffhunk://#diff-83269bc0833059dd2809362ce47173a8ce6b57708ba6e2664207264268fd6e16R17-R20) [[5]](diffhunk://#diff-83269bc0833059dd2809362ce47173a8ce6b57708ba6e2664207264268fd6e16R124-R125) [[6]](diffhunk://#diff-83269bc0833059dd2809362ce47173a8ce6b57708ba6e2664207264268fd6e16R141-R144) [[7]](diffhunk://#diff-83269bc0833059dd2809362ce47173a8ce6b57708ba6e2664207264268fd6e16R228-R237)

**UI and Route Updates**

* Built the `/reminders` route and all core UI components for creating, editing, and deleting reminders, including `ReminderItem`, `RecurrencePicker`, and `ReminderDialog`. Navigation and layout context updated to support reminders.
* Updated `DayView.tsx` to display a bell indicator for tasks and notes with reminders, using the new schedules query. (`src/components/DayView.tsx`) [[1]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R22) [[2]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R43-R47) [[3]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R125) [[4]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R140) [[5]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R155) [[6]](diffhunk://#diff-73a70f78be4292420e043e32223d7ff08fdefc21807880778defeeac65d99140R184)

**Backend and Data Layer**

* Added events adapter and schedules support in the backend: types, constants, queries, mutations, and seed data for events, following the same pattern as tasks and notes.

**Verification**

* All new and existing features pass type checks, unit tests, and end-to-end tests. [[1]](diffhunk://#diff-4b33a3db8417ff4191f7c7b7ffbc0c8c8cae1f55f6aca024d5043be4354723a6L659-R677) [[2]](diffhunk://#diff-4b33a3db8417ff4191f7c7b7ffbc0c8c8cae1f55f6aca024d5043be4354723a6L739-R773) [[3]](diffhunk://#diff-4b33a3db8417ff4191f7c7b7ffbc0c8c8cae1f55f6aca024d5043be4354723a6L821-R835)

**Other Integration**

* Updated `DayView.tsx`, `routes/_app/backlog.tsx`, and `routes/_app/notes.tsx` to wire up the `hasReminder` property using schedules queries, ensuring reminders are visible throughout the app.

These changes collectively add robust, reusable support for reminders (schedules) on tasks and notes, with a consistent user experience and full CRUD support.